### PR TITLE
Better ux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     compile 'commons-io:commons-io:2.5'
     compile 'com.google.code.gson:gson:2.6.2'
     compile 'com.google.guava:guava:19.0'
-    compileOnly files('/path/to/yaml/plugin/jar')
+    compileOnly files('/Applications/IntelliJ IDEA CE.app/Contents/plugins/yaml/lib/yaml.jar')
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.mockito:mockito-all:1.10.19'
-    testCompile files('/path/to/yaml/plugin/jar')
+    testCompile files('/Applications/IntelliJ IDEA CE.app/Contents/plugins/yaml/lib/yaml.jar')
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/SwaggerJsonCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/SwaggerJsonCompletionContributor.java
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.level.LevelCompletionFactory;
+import org.zalando.intellij.swagger.completion.level.inserthandler.JsonInsertHandler;
 import org.zalando.intellij.swagger.completion.level.value.ValueCompletionFactory;
 import org.zalando.intellij.swagger.completion.traversal.JsonTraversal;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
@@ -15,16 +16,19 @@ public class SwaggerJsonCompletionContributor extends CompletionContributor {
 
     private FileDetector fileDetector;
     private JsonTraversal jsonTraversal;
+    private JsonInsertHandler jsonInsertHandler;
 
     /* Constructor for IntelliJ IDEA bootstrap */
     public SwaggerJsonCompletionContributor() {
-        this(new FileDetector(), new JsonTraversal());
+        this(new FileDetector(), new JsonTraversal(), new JsonInsertHandler());
     }
 
-    private SwaggerJsonCompletionContributor(FileDetector fileDetector,
-                                             JsonTraversal jsonTraversal) {
+    private SwaggerJsonCompletionContributor(final FileDetector fileDetector,
+                                             final JsonTraversal jsonTraversal,
+                                             final JsonInsertHandler jsonInsertHandler) {
         this.fileDetector = fileDetector;
         this.jsonTraversal = jsonTraversal;
+        this.jsonInsertHandler = jsonInsertHandler;
     }
 
     @Override
@@ -37,7 +41,7 @@ public class SwaggerJsonCompletionContributor extends CompletionContributor {
         final PositionResolver positionResolver = new PositionResolver(psiElement, jsonTraversal);
         if (jsonTraversal.isKey(psiElement)) {
             LevelCompletionFactory.from(positionResolver)
-                    .ifPresent(levelCompletion -> levelCompletion.fill(result));
+                    .ifPresent(levelCompletion -> levelCompletion.fill(result, jsonInsertHandler));
         } else {
             ValueCompletionFactory.from(positionResolver)
                     .ifPresent(valueCompletion -> valueCompletion.fill(result));

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/SwaggerYamlCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/SwaggerYamlCompletionContributor.java
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.psi.YAMLKeyValue;
 import org.zalando.intellij.swagger.completion.level.LevelCompletionFactory;
+import org.zalando.intellij.swagger.completion.level.inserthandler.YamlInsertHandler;
 import org.zalando.intellij.swagger.completion.level.value.ValueCompletionFactory;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 import org.zalando.intellij.swagger.completion.traversal.YamlTraversal;
@@ -14,18 +15,21 @@ import org.zalando.intellij.swagger.file.FileDetector;
 
 public class SwaggerYamlCompletionContributor extends CompletionContributor {
 
-    private FileDetector fileDetector;
-    private YamlTraversal yamlTraversal;
+    private final FileDetector fileDetector;
+    private final YamlTraversal yamlTraversal;
+    private final YamlInsertHandler yamlInsertHandler;
 
     /* Constructor for IntelliJ IDEA bootstrap */
     public SwaggerYamlCompletionContributor() {
-        this(new FileDetector(), new YamlTraversal());
+        this(new FileDetector(), new YamlTraversal(), new YamlInsertHandler());
     }
 
-    private SwaggerYamlCompletionContributor(FileDetector fileDetector,
-                                             YamlTraversal yamlTraversal) {
+    private SwaggerYamlCompletionContributor(final FileDetector fileDetector,
+                                             final YamlTraversal yamlTraversal,
+                                             final YamlInsertHandler yamlInsertHandler) {
         this.fileDetector = fileDetector;
         this.yamlTraversal = yamlTraversal;
+        this.yamlInsertHandler = yamlInsertHandler;
     }
 
     @Override
@@ -41,7 +45,7 @@ public class SwaggerYamlCompletionContributor extends CompletionContributor {
 
         final PositionResolver positionResolver = new PositionResolver(psiElement, yamlTraversal);
         LevelCompletionFactory.from(positionResolver)
-                .ifPresent(levelCompletion -> levelCompletion.fill(result));
+                .ifPresent(levelCompletion -> levelCompletion.fill(result, yamlInsertHandler));
 
         ValueCompletionFactory.from(positionResolver)
                 .ifPresent(valueCompletion -> valueCompletion.fill(result));

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/ContactLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/ContactLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -9,15 +11,16 @@ import static org.zalando.intellij.swagger.completion.style.CompletionStyleFacto
 
 class ContactLevelCompletion extends LevelCompletion {
 
-
     ContactLevelCompletion(final PositionResolver positionResolver) {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("name", optional(positionResolver)));
-        result.addElement(create("url", optional(positionResolver)));
-        result.addElement(create("email", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("name", optional(positionResolver), insertHandler));
+        result.addElement(create("url", optional(positionResolver), insertHandler));
+        result.addElement(create("email", optional(positionResolver), insertHandler));
+
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/DefinitionsLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/DefinitionsLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -11,8 +13,9 @@ class DefinitionsLevelCompletion extends LevelCompletion {
     }
 
     @Override
-    public void fill(@NotNull final CompletionResultSet result) {
-        new SchemaLevelCompletion(positionResolver).fill(result);
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        new SchemaLevelCompletion(positionResolver).fill(result, insertHandler);
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/ExternalDocsLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/ExternalDocsLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -13,8 +15,9 @@ class ExternalDocsLevelCompletion extends LevelCompletion {
     }
 
     @Override
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(LookupElementBuilderFactory.create("description", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("url", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(LookupElementBuilderFactory.create("description", optional(positionResolver), insertHandler));
+        result.addElement(LookupElementBuilderFactory.create("url", optional(positionResolver), insertHandler));
     }
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/HeaderLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/HeaderLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -15,24 +17,25 @@ class HeaderLevelCompletion extends LevelCompletion {
     }
 
     @Override
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("description", optional(positionResolver)));
-        result.addElement(create("type", required(positionResolver)));
-        result.addElement(create("format", optional(positionResolver)));
-        result.addElement(create("items", optional(positionResolver)));
-        result.addElement(create("collectionFormat", optional(positionResolver)));
-        result.addElement(create("default", optional(positionResolver)));
-        result.addElement(create("maximum", optional(positionResolver)));
-        result.addElement(create("exclusiveMaximum", optional(positionResolver)));
-        result.addElement(create("minimum", optional(positionResolver)));
-        result.addElement(create("exclusiveMinimum", optional(positionResolver)));
-        result.addElement(create("maxLength", optional(positionResolver)));
-        result.addElement(create("minLength", optional(positionResolver)));
-        result.addElement(create("pattern", optional(positionResolver)));
-        result.addElement(create("maxItems", optional(positionResolver)));
-        result.addElement(create("minItems", optional(positionResolver)));
-        result.addElement(create("uniqueItems", optional(positionResolver)));
-        result.addElement(create("enum", optional(positionResolver)));
-        result.addElement(create("multipleOf", optional(positionResolver)));        
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("description", optional(positionResolver), insertHandler));
+        result.addElement(create("type", required(positionResolver), insertHandler));
+        result.addElement(create("format", optional(positionResolver), insertHandler));
+        result.addElement(create("items", optional(positionResolver), insertHandler));
+        result.addElement(create("collectionFormat", optional(positionResolver), insertHandler));
+        result.addElement(create("default", optional(positionResolver), insertHandler));
+        result.addElement(create("maximum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMaximum", optional(positionResolver), insertHandler));
+        result.addElement(create("minimum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMinimum", optional(positionResolver), insertHandler));
+        result.addElement(create("maxLength", optional(positionResolver), insertHandler));
+        result.addElement(create("minLength", optional(positionResolver), insertHandler));
+        result.addElement(create("pattern", optional(positionResolver), insertHandler));
+        result.addElement(create("maxItems", optional(positionResolver), insertHandler));
+        result.addElement(create("minItems", optional(positionResolver), insertHandler));
+        result.addElement(create("uniqueItems", optional(positionResolver), insertHandler));
+        result.addElement(create("enum", optional(positionResolver), insertHandler));
+        result.addElement(create("multipleOf", optional(positionResolver), insertHandler));
     }
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/InfoLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/InfoLevelCompletion.java
@@ -1,9 +1,12 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
+import static org.zalando.intellij.swagger.completion.level.LookupElementBuilderFactory.*;
 import static org.zalando.intellij.swagger.completion.style.CompletionStyleFactory.optional;
 import static org.zalando.intellij.swagger.completion.style.CompletionStyleFactory.required;
 
@@ -13,13 +16,14 @@ class InfoLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(LookupElementBuilderFactory.create("title", required(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("description", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("termsOfService", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("contact", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("license", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("version", required(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("title", required(positionResolver), insertHandler));
+        result.addElement(create("description", optional(positionResolver), insertHandler));
+        result.addElement(create("termsOfService", optional(positionResolver), insertHandler));
+        result.addElement(create("contact", optional(positionResolver), insertHandler));
+        result.addElement(create("license", optional(positionResolver), insertHandler));
+        result.addElement(create("version", required(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/ItemsLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/ItemsLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,24 +16,25 @@ class ItemsLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("type", required(positionResolver)));
-        result.addElement(create("format", optional(positionResolver)));
-        result.addElement(create("items", optional(positionResolver)));
-        result.addElement(create("collectionFormat", optional(positionResolver)));
-        result.addElement(create("default", optional(positionResolver)));
-        result.addElement(create("maximum", optional(positionResolver)));
-        result.addElement(create("exclusiveMaximum", optional(positionResolver)));
-        result.addElement(create("minimum", optional(positionResolver)));
-        result.addElement(create("exclusiveMinimum", optional(positionResolver)));
-        result.addElement(create("maxLength", optional(positionResolver)));
-        result.addElement(create("minLength", optional(positionResolver)));
-        result.addElement(create("pattern", optional(positionResolver)));
-        result.addElement(create("maxItems", optional(positionResolver)));
-        result.addElement(create("minItems", optional(positionResolver)));
-        result.addElement(create("uniqueItems", optional(positionResolver)));
-        result.addElement(create("enum", optional(positionResolver)));
-        result.addElement(create("multipleOf", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("type", required(positionResolver), insertHandler));
+        result.addElement(create("format", optional(positionResolver), insertHandler));
+        result.addElement(create("items", optional(positionResolver), insertHandler));
+        result.addElement(create("collectionFormat", optional(positionResolver), insertHandler));
+        result.addElement(create("default", optional(positionResolver), insertHandler));
+        result.addElement(create("maximum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMaximum", optional(positionResolver), insertHandler));
+        result.addElement(create("minimum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMinimum", optional(positionResolver), insertHandler));
+        result.addElement(create("maxLength", optional(positionResolver), insertHandler));
+        result.addElement(create("minLength", optional(positionResolver), insertHandler));
+        result.addElement(create("pattern", optional(positionResolver), insertHandler));
+        result.addElement(create("maxItems", optional(positionResolver), insertHandler));
+        result.addElement(create("minItems", optional(positionResolver), insertHandler));
+        result.addElement(create("uniqueItems", optional(positionResolver), insertHandler));
+        result.addElement(create("enum", optional(positionResolver), insertHandler));
+        result.addElement(create("multipleOf", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/LevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/LevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -12,5 +14,6 @@ public abstract class LevelCompletion {
         this.positionResolver = positionResolver;
     }
 
-    public abstract void fill(@NotNull final CompletionResultSet result);
+    public abstract void fill(@NotNull final CompletionResultSet result,
+                              @NotNull final InsertHandler<LookupElement> insertHandler);
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/LevelCompletionFactory.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/LevelCompletionFactory.java
@@ -1,5 +1,7 @@
 package org.zalando.intellij.swagger.completion.level;
 
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
 import java.util.Optional;

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/LicenseLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/LicenseLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,9 +16,10 @@ class LicenseLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("name", required(positionResolver)));
-        result.addElement(create("url", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("name", required(positionResolver), insertHandler));
+        result.addElement(create("url", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/LookupElementBuilderFactory.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/LookupElementBuilderFactory.java
@@ -1,5 +1,7 @@
 package org.zalando.intellij.swagger.completion.level;
 
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import org.zalando.intellij.swagger.completion.style.CompletionStyle;
 
@@ -15,6 +17,12 @@ public class LookupElementBuilderFactory {
         }
 
         return lookupElementBuilder;
+    }
+
+    public static LookupElementBuilder create(final String lookup,
+                                              final CompletionStyle completionStyle,
+                                              final InsertHandler<LookupElement> insertHandler) {
+        return create(lookup, completionStyle).withInsertHandler(insertHandler);
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/OperationLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/OperationLevelCompletion.java
@@ -1,9 +1,12 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
+import static org.zalando.intellij.swagger.completion.level.LookupElementBuilderFactory.*;
 import static org.zalando.intellij.swagger.completion.style.CompletionStyleFactory.optional;
 import static org.zalando.intellij.swagger.completion.style.CompletionStyleFactory.required;
 
@@ -13,19 +16,20 @@ class OperationLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(LookupElementBuilderFactory.create("tags", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("summary", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("description", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("externalDocs", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("operationId", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("consumes", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("produces", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("parameters", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("responses", required(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("schemes", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("deprecated", optional(positionResolver)));
-        result.addElement(LookupElementBuilderFactory.create("security", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("tags", optional(positionResolver), insertHandler));
+        result.addElement(create("summary", optional(positionResolver), insertHandler));
+        result.addElement(create("description", optional(positionResolver), insertHandler));
+        result.addElement(create("externalDocs", optional(positionResolver), insertHandler));
+        result.addElement(create("operationId", optional(positionResolver), insertHandler));
+        result.addElement(create("consumes", optional(positionResolver), insertHandler));
+        result.addElement(create("produces", optional(positionResolver), insertHandler));
+        result.addElement(create("parameters", optional(positionResolver), insertHandler));
+        result.addElement(create("responses", required(positionResolver), insertHandler));
+        result.addElement(create("schemes", optional(positionResolver), insertHandler));
+        result.addElement(create("deprecated", optional(positionResolver), insertHandler));
+        result.addElement(create("security", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/ParameterDefinitionLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/ParameterDefinitionLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -10,8 +12,9 @@ class ParameterDefinitionLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        new ParametersLevelCompletion(positionResolver).fill(result);
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        new ParametersLevelCompletion(positionResolver).fill(result, insertHandler);
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/ParametersLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/ParametersLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,30 +16,31 @@ class ParametersLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("name", required(positionResolver)));
-        result.addElement(create("in", required(positionResolver)));
-        result.addElement(create("description", optional(positionResolver)));
-        result.addElement(create("required", optional(positionResolver)));
-        result.addElement(create("schema", optional(positionResolver)));
-        result.addElement(create("type", optional(positionResolver)));
-        result.addElement(create("format", optional(positionResolver)));
-        result.addElement(create("allowEmptyValue", optional(positionResolver)));
-        result.addElement(create("items", optional(positionResolver)));
-        result.addElement(create("collectionFormat", optional(positionResolver)));
-        result.addElement(create("default", optional(positionResolver)));
-        result.addElement(create("maximum", optional(positionResolver)));
-        result.addElement(create("exclusiveMaximum", optional(positionResolver)));
-        result.addElement(create("minimum", optional(positionResolver)));
-        result.addElement(create("exclusiveMinimum", optional(positionResolver)));
-        result.addElement(create("maxLength", optional(positionResolver)));
-        result.addElement(create("minLength", optional(positionResolver)));
-        result.addElement(create("pattern", optional(positionResolver)));
-        result.addElement(create("maxItems", optional(positionResolver)));
-        result.addElement(create("minItems", optional(positionResolver)));
-        result.addElement(create("uniqueItems", optional(positionResolver)));
-        result.addElement(create("enum", optional(positionResolver)));
-        result.addElement(create("multipleOf", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("name", required(positionResolver), insertHandler));
+        result.addElement(create("in", required(positionResolver), insertHandler));
+        result.addElement(create("description", optional(positionResolver), insertHandler));
+        result.addElement(create("required", optional(positionResolver), insertHandler));
+        result.addElement(create("schema", optional(positionResolver), insertHandler));
+        result.addElement(create("type", optional(positionResolver), insertHandler));
+        result.addElement(create("format", optional(positionResolver), insertHandler));
+        result.addElement(create("allowEmptyValue", optional(positionResolver), insertHandler));
+        result.addElement(create("items", optional(positionResolver), insertHandler));
+        result.addElement(create("collectionFormat", optional(positionResolver), insertHandler));
+        result.addElement(create("default", optional(positionResolver), insertHandler));
+        result.addElement(create("maximum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMaximum", optional(positionResolver), insertHandler));
+        result.addElement(create("minimum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMinimum", optional(positionResolver), insertHandler));
+        result.addElement(create("maxLength", optional(positionResolver), insertHandler));
+        result.addElement(create("minLength", optional(positionResolver), insertHandler));
+        result.addElement(create("pattern", optional(positionResolver), insertHandler));
+        result.addElement(create("maxItems", optional(positionResolver), insertHandler));
+        result.addElement(create("minItems", optional(positionResolver), insertHandler));
+        result.addElement(create("uniqueItems", optional(positionResolver), insertHandler));
+        result.addElement(create("enum", optional(positionResolver), insertHandler));
+        result.addElement(create("multipleOf", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/PathLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/PathLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -13,16 +15,17 @@ class PathLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("$ref", optional(positionResolver)));
-        result.addElement(create("get", optional(positionResolver)));
-        result.addElement(create("put", optional(positionResolver)));
-        result.addElement(create("post", optional(positionResolver)));
-        result.addElement(create("delete", optional(positionResolver)));
-        result.addElement(create("options", optional(positionResolver)));
-        result.addElement(create("head", optional(positionResolver)));
-        result.addElement(create("patch", optional(positionResolver)));
-        result.addElement(create("parameters", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("$ref", optional(positionResolver), insertHandler));
+        result.addElement(create("get", optional(positionResolver), insertHandler));
+        result.addElement(create("put", optional(positionResolver), insertHandler));
+        result.addElement(create("post", optional(positionResolver), insertHandler));
+        result.addElement(create("delete", optional(positionResolver), insertHandler));
+        result.addElement(create("options", optional(positionResolver), insertHandler));
+        result.addElement(create("head", optional(positionResolver), insertHandler));
+        result.addElement(create("patch", optional(positionResolver), insertHandler));
+        result.addElement(create("parameters", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/ResponseLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/ResponseLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,11 +16,12 @@ class ResponseLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("description", required(positionResolver)));
-        result.addElement(create("schema", optional(positionResolver)));
-        result.addElement(create("headers", optional(positionResolver)));
-        result.addElement(create("examples", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("description", required(positionResolver), insertHandler));
+        result.addElement(create("schema", optional(positionResolver), insertHandler));
+        result.addElement(create("headers", optional(positionResolver), insertHandler));
+        result.addElement(create("examples", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/ResponsesLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/ResponsesLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -13,69 +15,70 @@ class ResponsesLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("default", optional(positionResolver)));
-        result.addElement(create("200", optional(positionResolver)));
-        result.addElement(create("201", optional(positionResolver)));
-        result.addElement(create("202", optional(positionResolver)));
-        result.addElement(create("203", optional(positionResolver)));
-        result.addElement(create("204", optional(positionResolver)));
-        result.addElement(create("205", optional(positionResolver)));
-        result.addElement(create("206", optional(positionResolver)));
-        result.addElement(create("207", optional(positionResolver)));
-        result.addElement(create("208", optional(positionResolver)));
-        result.addElement(create("226", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("default", optional(positionResolver), insertHandler));
+        result.addElement(create("200", optional(positionResolver), insertHandler));
+        result.addElement(create("201", optional(positionResolver), insertHandler));
+        result.addElement(create("202", optional(positionResolver), insertHandler));
+        result.addElement(create("203", optional(positionResolver), insertHandler));
+        result.addElement(create("204", optional(positionResolver), insertHandler));
+        result.addElement(create("205", optional(positionResolver), insertHandler));
+        result.addElement(create("206", optional(positionResolver), insertHandler));
+        result.addElement(create("207", optional(positionResolver), insertHandler));
+        result.addElement(create("208", optional(positionResolver), insertHandler));
+        result.addElement(create("226", optional(positionResolver), insertHandler));
 
-        result.addElement(create("300", optional(positionResolver)));
-        result.addElement(create("301", optional(positionResolver)));
-        result.addElement(create("302", optional(positionResolver)));
-        result.addElement(create("303", optional(positionResolver)));
-        result.addElement(create("304", optional(positionResolver)));
-        result.addElement(create("305", optional(positionResolver)));
-        result.addElement(create("306", optional(positionResolver)));
-        result.addElement(create("307", optional(positionResolver)));
-        result.addElement(create("308", optional(positionResolver)));
+        result.addElement(create("300", optional(positionResolver), insertHandler));
+        result.addElement(create("301", optional(positionResolver), insertHandler));
+        result.addElement(create("302", optional(positionResolver), insertHandler));
+        result.addElement(create("303", optional(positionResolver), insertHandler));
+        result.addElement(create("304", optional(positionResolver), insertHandler));
+        result.addElement(create("305", optional(positionResolver), insertHandler));
+        result.addElement(create("306", optional(positionResolver), insertHandler));
+        result.addElement(create("307", optional(positionResolver), insertHandler));
+        result.addElement(create("308", optional(positionResolver), insertHandler));
 
-        result.addElement(create("400", optional(positionResolver)));
-        result.addElement(create("401", optional(positionResolver)));
-        result.addElement(create("402", optional(positionResolver)));
-        result.addElement(create("403", optional(positionResolver)));
-        result.addElement(create("404", optional(positionResolver)));
-        result.addElement(create("405", optional(positionResolver)));
-        result.addElement(create("406", optional(positionResolver)));
-        result.addElement(create("407", optional(positionResolver)));
-        result.addElement(create("408", optional(positionResolver)));
-        result.addElement(create("409", optional(positionResolver)));
-        result.addElement(create("410", optional(positionResolver)));
-        result.addElement(create("411", optional(positionResolver)));
-        result.addElement(create("412", optional(positionResolver)));
-        result.addElement(create("413", optional(positionResolver)));
-        result.addElement(create("414", optional(positionResolver)));
-        result.addElement(create("415", optional(positionResolver)));
-        result.addElement(create("416", optional(positionResolver)));
-        result.addElement(create("417", optional(positionResolver)));
-        result.addElement(create("418", optional(positionResolver)));
-        result.addElement(create("421", optional(positionResolver)));
-        result.addElement(create("422", optional(positionResolver)));
-        result.addElement(create("423", optional(positionResolver)));
-        result.addElement(create("424", optional(positionResolver)));
-        result.addElement(create("426", optional(positionResolver)));
-        result.addElement(create("428", optional(positionResolver)));
-        result.addElement(create("429", optional(positionResolver)));
-        result.addElement(create("431", optional(positionResolver)));
-        result.addElement(create("451", optional(positionResolver)));
+        result.addElement(create("400", optional(positionResolver), insertHandler));
+        result.addElement(create("401", optional(positionResolver), insertHandler));
+        result.addElement(create("402", optional(positionResolver), insertHandler));
+        result.addElement(create("403", optional(positionResolver), insertHandler));
+        result.addElement(create("404", optional(positionResolver), insertHandler));
+        result.addElement(create("405", optional(positionResolver), insertHandler));
+        result.addElement(create("406", optional(positionResolver), insertHandler));
+        result.addElement(create("407", optional(positionResolver), insertHandler));
+        result.addElement(create("408", optional(positionResolver), insertHandler));
+        result.addElement(create("409", optional(positionResolver), insertHandler));
+        result.addElement(create("410", optional(positionResolver), insertHandler));
+        result.addElement(create("411", optional(positionResolver), insertHandler));
+        result.addElement(create("412", optional(positionResolver), insertHandler));
+        result.addElement(create("413", optional(positionResolver), insertHandler));
+        result.addElement(create("414", optional(positionResolver), insertHandler));
+        result.addElement(create("415", optional(positionResolver), insertHandler));
+        result.addElement(create("416", optional(positionResolver), insertHandler));
+        result.addElement(create("417", optional(positionResolver), insertHandler));
+        result.addElement(create("418", optional(positionResolver), insertHandler));
+        result.addElement(create("421", optional(positionResolver), insertHandler));
+        result.addElement(create("422", optional(positionResolver), insertHandler));
+        result.addElement(create("423", optional(positionResolver), insertHandler));
+        result.addElement(create("424", optional(positionResolver), insertHandler));
+        result.addElement(create("426", optional(positionResolver), insertHandler));
+        result.addElement(create("428", optional(positionResolver), insertHandler));
+        result.addElement(create("429", optional(positionResolver), insertHandler));
+        result.addElement(create("431", optional(positionResolver), insertHandler));
+        result.addElement(create("451", optional(positionResolver), insertHandler));
 
-        result.addElement(create("500", optional(positionResolver)));
-        result.addElement(create("501", optional(positionResolver)));
-        result.addElement(create("502", optional(positionResolver)));
-        result.addElement(create("503", optional(positionResolver)));
-        result.addElement(create("504", optional(positionResolver)));
-        result.addElement(create("505", optional(positionResolver)));
-        result.addElement(create("506", optional(positionResolver)));
-        result.addElement(create("507", optional(positionResolver)));
-        result.addElement(create("508", optional(positionResolver)));
-        result.addElement(create("510", optional(positionResolver)));
-        result.addElement(create("511", optional(positionResolver)));
+        result.addElement(create("500", optional(positionResolver), insertHandler));
+        result.addElement(create("501", optional(positionResolver), insertHandler));
+        result.addElement(create("502", optional(positionResolver), insertHandler));
+        result.addElement(create("503", optional(positionResolver), insertHandler));
+        result.addElement(create("504", optional(positionResolver), insertHandler));
+        result.addElement(create("505", optional(positionResolver), insertHandler));
+        result.addElement(create("506", optional(positionResolver), insertHandler));
+        result.addElement(create("507", optional(positionResolver), insertHandler));
+        result.addElement(create("508", optional(positionResolver), insertHandler));
+        result.addElement(create("510", optional(positionResolver), insertHandler));
+        result.addElement(create("511", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/RootLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/RootLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,22 +16,23 @@ class RootLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("swagger", required(positionResolver)));
-        result.addElement(create("info", required(positionResolver)));
-        result.addElement(create("host", optional(positionResolver)));
-        result.addElement(create("basePath", optional(positionResolver)));
-        result.addElement(create("schemes", optional(positionResolver)));
-        result.addElement(create("consumes", optional(positionResolver)));
-        result.addElement(create("produces", optional(positionResolver)));
-        result.addElement(create("paths", required(positionResolver)));
-        result.addElement(create("definitions", optional(positionResolver)));
-        result.addElement(create("parameters", optional(positionResolver)));
-        result.addElement(create("responses", optional(positionResolver)));
-        result.addElement(create("securityDefinitions", optional(positionResolver)));
-        result.addElement(create("security", optional(positionResolver)));
-        result.addElement(create("tags", optional(positionResolver)));
-        result.addElement(create("externalDocs", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("swagger", required(positionResolver), insertHandler));
+        result.addElement(create("info", required(positionResolver), insertHandler));
+        result.addElement(create("host", optional(positionResolver), insertHandler));
+        result.addElement(create("basePath", optional(positionResolver), insertHandler));
+        result.addElement(create("schemes", optional(positionResolver), insertHandler));
+        result.addElement(create("consumes", optional(positionResolver), insertHandler));
+        result.addElement(create("produces", optional(positionResolver), insertHandler));
+        result.addElement(create("paths", required(positionResolver), insertHandler));
+        result.addElement(create("definitions", optional(positionResolver), insertHandler));
+        result.addElement(create("parameters", optional(positionResolver), insertHandler));
+        result.addElement(create("responses", optional(positionResolver), insertHandler));
+        result.addElement(create("securityDefinitions", optional(positionResolver), insertHandler));
+        result.addElement(create("security", optional(positionResolver), insertHandler));
+        result.addElement(create("tags", optional(positionResolver), insertHandler));
+        result.addElement(create("externalDocs", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/SchemaLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/SchemaLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,36 +16,37 @@ public class SchemaLevelCompletion extends LevelCompletion {
     }
 
     @Override
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("$ref", optional(positionResolver)));
-        result.addElement(create("format", optional(positionResolver)));
-        result.addElement(create("title", optional(positionResolver)));
-        result.addElement(create("description", optional(positionResolver)));
-        result.addElement(create("default", optional(positionResolver)));
-        result.addElement(create("multipleOf", optional(positionResolver)));
-        result.addElement(create("maximum", optional(positionResolver)));
-        result.addElement(create("exclusiveMaximum", optional(positionResolver)));
-        result.addElement(create("minimum", optional(positionResolver)));
-        result.addElement(create("exclusiveMinimum", optional(positionResolver)));
-        result.addElement(create("maxLength", optional(positionResolver)));
-        result.addElement(create("minLength", optional(positionResolver)));
-        result.addElement(create("pattern", optional(positionResolver)));
-        result.addElement(create("maxItems", optional(positionResolver)));
-        result.addElement(create("minItems", optional(positionResolver)));
-        result.addElement(create("uniqueItems", optional(positionResolver)));
-        result.addElement(create("maxProperties", optional(positionResolver)));
-        result.addElement(create("minProperties", optional(positionResolver)));
-        result.addElement(create("required", optional(positionResolver)));
-        result.addElement(create("enum", optional(positionResolver)));
-        result.addElement(create("type", optional(positionResolver)));
-        result.addElement(create("items", optional(positionResolver)));
-        result.addElement(create("allOf", optional(positionResolver)));
-        result.addElement(create("properties", optional(positionResolver)));
-        result.addElement(create("additionalProperties", optional(positionResolver)));
-        result.addElement(create("discriminator", optional(positionResolver)));
-        result.addElement(create("readOnly", optional(positionResolver)));
-        result.addElement(create("xml", optional(positionResolver)));
-        result.addElement(create("externalDocs", optional(positionResolver)));
-        result.addElement(create("example", optional(positionResolver)));        
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("$ref", optional(positionResolver), insertHandler));
+        result.addElement(create("format", optional(positionResolver), insertHandler));
+        result.addElement(create("title", optional(positionResolver), insertHandler));
+        result.addElement(create("description", optional(positionResolver), insertHandler));
+        result.addElement(create("default", optional(positionResolver), insertHandler));
+        result.addElement(create("multipleOf", optional(positionResolver), insertHandler));
+        result.addElement(create("maximum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMaximum", optional(positionResolver), insertHandler));
+        result.addElement(create("minimum", optional(positionResolver), insertHandler));
+        result.addElement(create("exclusiveMinimum", optional(positionResolver), insertHandler));
+        result.addElement(create("maxLength", optional(positionResolver), insertHandler));
+        result.addElement(create("minLength", optional(positionResolver), insertHandler));
+        result.addElement(create("pattern", optional(positionResolver), insertHandler));
+        result.addElement(create("maxItems", optional(positionResolver), insertHandler));
+        result.addElement(create("minItems", optional(positionResolver), insertHandler));
+        result.addElement(create("uniqueItems", optional(positionResolver), insertHandler));
+        result.addElement(create("maxProperties", optional(positionResolver), insertHandler));
+        result.addElement(create("minProperties", optional(positionResolver), insertHandler));
+        result.addElement(create("required", optional(positionResolver), insertHandler));
+        result.addElement(create("enum", optional(positionResolver), insertHandler));
+        result.addElement(create("type", optional(positionResolver), insertHandler));
+        result.addElement(create("items", optional(positionResolver), insertHandler));
+        result.addElement(create("allOf", optional(positionResolver), insertHandler));
+        result.addElement(create("properties", optional(positionResolver), insertHandler));
+        result.addElement(create("additionalProperties", optional(positionResolver), insertHandler));
+        result.addElement(create("discriminator", optional(positionResolver), insertHandler));
+        result.addElement(create("readOnly", optional(positionResolver), insertHandler));
+        result.addElement(create("xml", optional(positionResolver), insertHandler));
+        result.addElement(create("externalDocs", optional(positionResolver), insertHandler));
+        result.addElement(create("example", optional(positionResolver), insertHandler));
     }
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/SecurityDefinitionLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/SecurityDefinitionLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,15 +16,16 @@ class SecurityDefinitionLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("type", required(positionResolver)));
-        result.addElement(create("description", optional(positionResolver)));
-        result.addElement(create("name", required(positionResolver)));
-        result.addElement(create("in", required(positionResolver)));
-        result.addElement(create("flow", required(positionResolver)));
-        result.addElement(create("authorizationUrl", required(positionResolver)));
-        result.addElement(create("tokenUrl", required(positionResolver)));
-        result.addElement(create("scopes", required(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("type", required(positionResolver), insertHandler));
+        result.addElement(create("description", optional(positionResolver), insertHandler));
+        result.addElement(create("name", required(positionResolver), insertHandler));
+        result.addElement(create("in", required(positionResolver), insertHandler));
+        result.addElement(create("flow", required(positionResolver), insertHandler));
+        result.addElement(create("authorizationUrl", required(positionResolver), insertHandler));
+        result.addElement(create("tokenUrl", required(positionResolver), insertHandler));
+        result.addElement(create("scopes", required(positionResolver), insertHandler));
 
     }
 

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/TagsLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/TagsLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -14,10 +16,11 @@ class TagsLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("name", required(positionResolver)));
-        result.addElement(create("description", optional(positionResolver)));
-        result.addElement(create("externalDocs", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("name", required(positionResolver), insertHandler));
+        result.addElement(create("description", optional(positionResolver), insertHandler));
+        result.addElement(create("externalDocs", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/XmlLevelCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/XmlLevelCompletion.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.completion.level;
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.lookup.LookupElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.traversal.PositionResolver;
 
@@ -13,12 +15,13 @@ class XmlLevelCompletion extends LevelCompletion {
         super(positionResolver);
     }
 
-    public void fill(@NotNull final CompletionResultSet result) {
-        result.addElement(create("name", optional(positionResolver)));
-        result.addElement(create("namespace", optional(positionResolver)));
-        result.addElement(create("prefix", optional(positionResolver)));
-        result.addElement(create("attribute", optional(positionResolver)));
-        result.addElement(create("wrapped", optional(positionResolver)));
+    public void fill(@NotNull final CompletionResultSet result,
+                     @NotNull final InsertHandler<LookupElement> insertHandler) {
+        result.addElement(create("name", optional(positionResolver), insertHandler));
+        result.addElement(create("namespace", optional(positionResolver), insertHandler));
+        result.addElement(create("prefix", optional(positionResolver), insertHandler));
+        result.addElement(create("attribute", optional(positionResolver), insertHandler));
+        result.addElement(create("wrapped", optional(positionResolver), insertHandler));
     }
 
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/JsonInsertHandler.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/JsonInsertHandler.java
@@ -1,0 +1,60 @@
+package org.zalando.intellij.swagger.completion.level.inserthandler;
+
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.editor.EditorModificationUtil;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.completion.level.string.StringUtils;
+import org.zalando.intellij.swagger.completion.type.FieldType;
+
+public class JsonInsertHandler implements InsertHandler<LookupElement> {
+
+    @Override
+    public void handleInsert(final InsertionContext context, final LookupElement item) {
+        if (!StringUtils.nextCharIsColon(getStringAfterAutoCompletedValue(context))) {
+            final FieldType fieldType = FieldType.fromFieldName(item.getLookupString());
+
+            if (fieldType == FieldType.ARRAY) {
+                insertArray(context, item);
+            } else if (fieldType == FieldType.OBJECT) {
+                insertObject(context, item);
+            } else {
+                insertString(context);
+            }
+        }
+    }
+
+    private void insertString(final InsertionContext context) {
+        final String stringToInsert = ": \"\"";
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, 3);
+    }
+
+    private void insertObject(final InsertionContext context, final LookupElement item) {
+        final String indentation = getIndentation(context, item);
+        final String stringToInsert = ": {\n" + indentation + 2 + "\n" + indentation + "}";
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, indentation.length() + 2);
+    }
+
+    private String getIndentation(final InsertionContext context, final LookupElement item) {
+        final String stringBeforeAutoCompletedValue = getStringBeforeAutoCompletedValue(context, item);
+        final int numberOfSpaces = StringUtils.getNumberOfSpacesInRowStartingFromEnd(stringBeforeAutoCompletedValue);
+        return org.apache.commons.lang.StringUtils.repeat(" ", numberOfSpaces + 2);
+    }
+
+    private void insertArray(final InsertionContext context, final LookupElement item) {
+        final String indentation = getIndentation(context, item);
+        final String stringToInsert = ":\n" + indentation + "- ";
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, stringToInsert.length());
+    }
+
+    @NotNull
+    private String getStringAfterAutoCompletedValue(final InsertionContext context) {
+        return context.getDocument().getText().substring(context.getTailOffset());
+    }
+
+    @NotNull
+    private String getStringBeforeAutoCompletedValue(final InsertionContext context, final LookupElement item) {
+        return context.getDocument().getText().substring(0, context.getTailOffset() - item.getLookupString().length());
+    }
+}

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/JsonInsertHandler.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/JsonInsertHandler.java
@@ -12,7 +12,7 @@ public class JsonInsertHandler implements InsertHandler<LookupElement> {
 
     @Override
     public void handleInsert(final InsertionContext context, final LookupElement item) {
-        if (!StringUtils.nextCharIsColon(getStringAfterAutoCompletedValue(context))) {
+        if (!StringUtils.nextCharAfterSpacesIsColonOrQuote(getStringAfterAutoCompletedValue(context))) {
             final FieldType fieldType = FieldType.fromFieldName(item.getLookupString());
 
             if (fieldType == FieldType.ARRAY) {
@@ -27,25 +27,27 @@ public class JsonInsertHandler implements InsertHandler<LookupElement> {
 
     private void insertString(final InsertionContext context) {
         final String stringToInsert = ": \"\"";
-        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, 3);
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, stringToInsert.length() - 1);
     }
 
     private void insertObject(final InsertionContext context, final LookupElement item) {
         final String indentation = getIndentation(context, item);
-        final String stringToInsert = ": {\n" + indentation + 2 + "\n" + indentation + "}";
-        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, indentation.length() + 2);
+        final String lineLeftPadding = org.apache.commons.lang.StringUtils.repeat(" ", indentation.length() + 2);
+        final String stringToInsert = ": {\n" + lineLeftPadding + "\n" + indentation + "}";
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, lineLeftPadding.length() + 4);
     }
 
     private String getIndentation(final InsertionContext context, final LookupElement item) {
         final String stringBeforeAutoCompletedValue = getStringBeforeAutoCompletedValue(context, item);
         final int numberOfSpaces = StringUtils.getNumberOfSpacesInRowStartingFromEnd(stringBeforeAutoCompletedValue);
-        return org.apache.commons.lang.StringUtils.repeat(" ", numberOfSpaces + 2);
+        return org.apache.commons.lang.StringUtils.repeat(" ", numberOfSpaces);
     }
 
     private void insertArray(final InsertionContext context, final LookupElement item) {
         final String indentation = getIndentation(context, item);
-        final String stringToInsert = ":\n" + indentation + "- ";
-        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, stringToInsert.length());
+        final String lineLeftPadding = org.apache.commons.lang.StringUtils.repeat(" ", indentation.length() + 2);
+        final String stringToInsert = ": [\n" + lineLeftPadding + "\n" + indentation + "]";
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, lineLeftPadding.length() + 4);
     }
 
     @NotNull

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/YamlInsertHandler.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/YamlInsertHandler.java
@@ -1,0 +1,60 @@
+package org.zalando.intellij.swagger.completion.level.inserthandler;
+
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.editor.EditorModificationUtil;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.completion.level.string.StringUtils;
+import org.zalando.intellij.swagger.completion.type.FieldType;
+
+public class YamlInsertHandler implements InsertHandler<LookupElement> {
+
+    @Override
+    public void handleInsert(final InsertionContext context, final LookupElement item) {
+        if (!StringUtils.nextCharIsColon(getStringAfterAutoCompletedValue(context))) {
+            final FieldType fieldType = FieldType.fromFieldName(item.getLookupString());
+
+            if (fieldType == FieldType.ARRAY) {
+                insertArray(context, item);
+            } else if (fieldType == FieldType.OBJECT) {
+                insertObject(context, item);
+            } else {
+                insertString(context);
+            }
+        }
+    }
+
+    private void insertString(final InsertionContext context) {
+        final String stringToInsert = ": ";
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, stringToInsert.length());
+    }
+
+    private void insertObject(final InsertionContext context, final LookupElement item) {
+        final String indentation = getIndentation(context, item);
+        final String stringToInsert = ":\n" + indentation;
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, stringToInsert.length());
+    }
+
+    private String getIndentation(final InsertionContext context, final LookupElement item) {
+        final String stringBeforeAutoCompletedValue = getStringBeforeAutoCompletedValue(context, item);
+        final int numberOfSpaces = StringUtils.getNumberOfSpacesInRowStartingFromEnd(stringBeforeAutoCompletedValue);
+        return org.apache.commons.lang.StringUtils.repeat(" ", numberOfSpaces + 2);
+    }
+
+    private void insertArray(final InsertionContext context, final LookupElement item) {
+        final String indentation = getIndentation(context, item);
+        final String stringToInsert = ":\n" + indentation + "- ";
+        EditorModificationUtil.insertStringAtCaret(context.getEditor(), stringToInsert, false, true, stringToInsert.length());
+    }
+
+    @NotNull
+    private String getStringAfterAutoCompletedValue(final InsertionContext context) {
+        return context.getDocument().getText().substring(context.getTailOffset());
+    }
+
+    @NotNull
+    private String getStringBeforeAutoCompletedValue(final InsertionContext context, final LookupElement item) {
+        return context.getDocument().getText().substring(0, context.getTailOffset() - item.getLookupString().length());
+    }
+}

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/YamlInsertHandler.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/inserthandler/YamlInsertHandler.java
@@ -12,7 +12,7 @@ public class YamlInsertHandler implements InsertHandler<LookupElement> {
 
     @Override
     public void handleInsert(final InsertionContext context, final LookupElement item) {
-        if (!StringUtils.nextCharIsColon(getStringAfterAutoCompletedValue(context))) {
+        if (!StringUtils.nextCharAfterSpacesIsColonOrQuote(getStringAfterAutoCompletedValue(context))) {
             final FieldType fieldType = FieldType.fromFieldName(item.getLookupString());
 
             if (fieldType == FieldType.ARRAY) {

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/string/StringUtils.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/string/StringUtils.java
@@ -2,11 +2,11 @@ package org.zalando.intellij.swagger.completion.level.string;
 
 public class StringUtils {
 
-    public static boolean nextCharIsColon(final String string) {
+    public static boolean nextCharAfterSpacesIsColonOrQuote(final String string) {
         for (int i = 0; i < string.length(); i++) {
             final char c = string.charAt(i);
             if (c != ' ') {
-                return c == ':';
+                return c == ':' || c == '\"';
             }
         }
         return false;
@@ -22,5 +22,9 @@ public class StringUtils {
             count++;
         }
         return count;
+    }
+
+    public static String removeAllQuotes(final String string) {
+        return string.replace("'", "").replace("\"", "");
     }
 }

--- a/src/main/java/org/zalando/intellij/swagger/completion/level/string/StringUtils.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/level/string/StringUtils.java
@@ -1,0 +1,26 @@
+package org.zalando.intellij.swagger.completion.level.string;
+
+public class StringUtils {
+
+    public static boolean nextCharIsColon(final String string) {
+        for (int i = 0; i < string.length(); i++) {
+            final char c = string.charAt(i);
+            if (c != ' ') {
+                return c == ':';
+            }
+        }
+        return false;
+    }
+
+    public static int getNumberOfSpacesInRowStartingFromEnd(final String string) {
+        int count = 0;
+        for (int i = string.length() - 1; i >= 0; i--) {
+            final char c = string.charAt(i);
+            if (c != ' ') {
+                return count;
+            }
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/main/java/org/zalando/intellij/swagger/completion/type/FieldType.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/type/FieldType.java
@@ -1,6 +1,7 @@
 package org.zalando.intellij.swagger.completion.type;
 
 import com.google.common.collect.Sets;
+import org.zalando.intellij.swagger.completion.level.string.StringUtils;
 
 import java.util.Set;
 
@@ -151,9 +152,10 @@ public enum FieldType {
     );
 
     public static FieldType fromFieldName(final String fieldName) {
-        if (ARRAY_FIELDS.contains(fieldName)) {
+        final String cleanedFieldName = StringUtils.removeAllQuotes(fieldName);
+        if (ARRAY_FIELDS.contains(cleanedFieldName)) {
             return ARRAY;
-        } else if (OBJECT_FIELDS.contains(fieldName)) {
+        } else if (OBJECT_FIELDS.contains(cleanedFieldName)) {
             return OBJECT;
         } else {
             return STRING;

--- a/src/main/java/org/zalando/intellij/swagger/completion/type/FieldType.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/type/FieldType.java
@@ -1,0 +1,162 @@
+package org.zalando.intellij.swagger.completion.type;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+public enum FieldType {
+
+    ARRAY, OBJECT, STRING;
+
+    private static final Set<String> ARRAY_FIELDS = Sets.newHashSet(
+            "enum",
+            "tags",
+            "consumes",
+            "produces",
+            "schemes",
+            "security",
+            "allOf"
+    );
+
+    private static final Set<String> OBJECT_FIELDS = Sets.newHashSet(
+            "items",
+            "externalDocs",
+            "parameters",
+            "responses",
+            "schema",
+            "get",
+            "put",
+            "post",
+            "delete",
+            "options",
+            "head",
+            "patch",
+            "parameters",
+            "headers",
+            "examples",
+            "info",
+            "paths",
+            "definitions",
+            "parameters",
+            "responses",
+            "securityDefinitions",
+            "properties",
+            "additionalProperties",
+            "xml",
+            "scopes",
+            "license",
+            "default",
+            "200",
+            "201",
+            "202",
+            "203",
+            "204",
+            "205",
+            "206",
+            "207",
+            "208",
+            "226",
+            "300",
+            "301",
+            "302",
+            "303",
+            "304",
+            "305",
+            "306",
+            "307",
+            "308",
+            "400",
+            "401",
+            "402",
+            "403",
+            "404",
+            "405",
+            "406",
+            "407",
+            "408",
+            "409",
+            "410",
+            "411",
+            "412",
+            "413",
+            "414",
+            "415",
+            "416",
+            "417",
+            "418",
+            "421",
+            "422",
+            "423",
+            "424",
+            "426",
+            "428",
+            "429",
+            "431",
+            "451",
+            "500",
+            "501",
+            "502",
+            "503",
+            "504",
+            "505",
+            "506",
+            "507",
+            "508",
+            "510",
+            "511"
+    );
+
+    private static final Set<String> STRING_FIELDS = Sets.newHashSet(
+            "name",
+            "url",
+            "email",
+            "description",
+            "type",
+            "format",
+            "collectionFormat",
+            "maximum",
+            "exclusiveMaximum",
+            "minimum",
+            "exclusiveMinimum",
+            "maxLength",
+            "minLength",
+            "pattern",
+            "maxItems",
+            "minItems",
+            "uniqueItems",
+            "multipleOf",
+            "title",
+            "termsOfService",
+            "contact",
+            "version",
+            "summary",
+            "operationId",
+            "deprecated",
+            "in",
+            "required",
+            "allowEmptyValue",
+            "$ref",
+            "swagger",
+            "host",
+            "basePath",
+            "discriminator",
+            "readOnly",
+            "flow",
+            "authorizationUrl",
+            "tokenUrl",
+            "namespace",
+            "prefix",
+            "attribute",
+            "wrapped"
+    );
+
+    public static FieldType fromFieldName(final String fieldName) {
+        if (ARRAY_FIELDS.contains(fieldName)) {
+            return ARRAY;
+        } else if (OBJECT_FIELDS.contains(fieldName)) {
+            return OBJECT;
+        } else {
+            return STRING;
+        }
+    }
+}

--- a/src/main/resources/META-INF/swagger.yaml
+++ b/src/main/resources/META-INF/swagger.yaml
@@ -1,0 +1,102 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - ws
+  - https
+consumes:
+  - application/xml
+produces:
+  - application/xml
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/src/test/java/org/zalando/intellij/swagger/completion/CaretCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/CaretCompletionTest.java
@@ -8,7 +8,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.zalando.intellij.swagger.completion.SwaggerFixture.JsonOrYaml;
+import org.zalando.intellij.swagger.fixture.SwaggerFixture;
+import org.zalando.intellij.swagger.fixture.SwaggerFixture.JsonOrYaml;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/org/zalando/intellij/swagger/completion/InsertHandlerTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/InsertHandlerTest.java
@@ -1,0 +1,55 @@
+package org.zalando.intellij.swagger.completion;
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.codeInsight.lookup.LookupManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.zalando.intellij.swagger.fixture.SwaggerFixture;
+import org.zalando.intellij.swagger.fixture.SwaggerFixture.JsonOrYaml;
+
+@RunWith(Parameterized.class)
+public class InsertHandlerTest {
+
+    private SwaggerFixture myFixture;
+    private final JsonOrYaml myJsonOrYaml;
+
+    @Parameterized.Parameters(name = "inputKind: {0}")
+    public static Object[] parameters() {
+        return JsonOrYaml.values();
+    }
+
+    public InsertHandlerTest(JsonOrYaml jsonOrYaml) {
+        myJsonOrYaml = jsonOrYaml;
+    }
+
+    @Before
+    public void setUpBefore() throws Exception {
+        myFixture = SwaggerFixture.forResourceFolder("testing/insert");
+    }
+
+    @After
+    public void tearDownAfter() throws Exception {
+        myFixture.tearDown();
+    }
+
+    @Test
+    public void thatStringFieldIsHandled() {
+        myFixture.complete("field_string", myJsonOrYaml);
+        myFixture.checkResultByFile("field_string_after", myJsonOrYaml);
+    }
+
+    @Test
+    public void thatObjectFieldIsHandled() {
+        myFixture.complete("field_object", myJsonOrYaml);
+        myFixture.checkResultByFile("field_object_after", myJsonOrYaml);
+    }
+
+    @Test
+    public void thatArrayFieldIsHandled() {
+        myFixture.complete("field_array", myJsonOrYaml);
+        myFixture.checkResultByFile("field_array_after", myJsonOrYaml);
+    }
+}

--- a/src/test/java/org/zalando/intellij/swagger/completion/level/string/StringUtilsTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/level/string/StringUtilsTest.java
@@ -1,0 +1,46 @@
+package org.zalando.intellij.swagger.completion.level.string;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StringUtilsTest {
+
+    @Test
+    public void thatReturnsTrueWhenNextCharIsColon() throws Exception {
+        assertTrue(StringUtils.nextCharIsColon(":"));
+    }
+
+    @Test
+    public void thatReturnsTrueWhenNextCharIsColonPrefixedBySpace() throws Exception {
+        assertTrue(StringUtils.nextCharIsColon(" :"));
+    }
+
+    @Test
+    public void thatReturnsFalseWhenNextCharIsNotColon() throws Exception {
+        assertFalse(StringUtils.nextCharIsColon("a:"));
+    }
+
+    @Test
+    public void thatReturnsFalseWhenOnlySpace() throws Exception {
+        assertFalse(StringUtils.nextCharIsColon(" "));
+    }
+
+    @Test
+    public void thatStringHasTwoSpacesInRow() throws Exception {
+        assertEquals(2, StringUtils.getNumberOfSpacesInRowStartingFromEnd("text  "));
+    }
+
+    @Test
+    public void thatStringHasNoSpacesInRow() throws Exception {
+        assertEquals(0, StringUtils.getNumberOfSpacesInRowStartingFromEnd("text"));
+    }
+
+    @Test
+    public void thatEmptyStringHasNoSpacesInRow() throws Exception {
+        assertEquals(0, StringUtils.getNumberOfSpacesInRowStartingFromEnd(""));
+    }
+
+}

--- a/src/test/java/org/zalando/intellij/swagger/completion/level/string/StringUtilsTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/level/string/StringUtilsTest.java
@@ -10,22 +10,32 @@ public class StringUtilsTest {
 
     @Test
     public void thatReturnsTrueWhenNextCharIsColon() throws Exception {
-        assertTrue(StringUtils.nextCharIsColon(":"));
+        assertTrue(StringUtils.nextCharAfterSpacesIsColonOrQuote(":"));
+    }
+
+    @Test
+    public void thatReturnsTrueWhenNextCharIsQuote() throws Exception {
+        assertTrue(StringUtils.nextCharAfterSpacesIsColonOrQuote("\""));
     }
 
     @Test
     public void thatReturnsTrueWhenNextCharIsColonPrefixedBySpace() throws Exception {
-        assertTrue(StringUtils.nextCharIsColon(" :"));
+        assertTrue(StringUtils.nextCharAfterSpacesIsColonOrQuote(" :"));
+    }
+
+    @Test
+    public void thatReturnsTrueWhenNextCharIsQuotePrefixedBySpace() throws Exception {
+        assertTrue(StringUtils.nextCharAfterSpacesIsColonOrQuote(" \""));
     }
 
     @Test
     public void thatReturnsFalseWhenNextCharIsNotColon() throws Exception {
-        assertFalse(StringUtils.nextCharIsColon("a:"));
+        assertFalse(StringUtils.nextCharAfterSpacesIsColonOrQuote("a:"));
     }
 
     @Test
     public void thatReturnsFalseWhenOnlySpace() throws Exception {
-        assertFalse(StringUtils.nextCharIsColon(" "));
+        assertFalse(StringUtils.nextCharAfterSpacesIsColonOrQuote(" "));
     }
 
     @Test

--- a/src/test/java/org/zalando/intellij/swagger/fixture/SwaggerFixture.java
+++ b/src/test/java/org/zalando/intellij/swagger/fixture/SwaggerFixture.java
@@ -1,5 +1,7 @@
-package org.zalando.intellij.swagger.completion;
+package org.zalando.intellij.swagger.fixture;
 
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.codeInsight.lookup.LookupManager;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
@@ -53,6 +55,18 @@ public class SwaggerFixture {
     public AssertableList getCompletions(@NotNull String caretFileNoExt, @NotNull JsonOrYaml fileKind) {
         String fullName = fileKind.getFileName(caretFileNoExt);
         return getCompletions(fullName);
+    }
+
+    public void complete(final String testFileNoExt, final JsonOrYaml fileKind) {
+        myCodeInsightFixture.configureByFile(fileKind.getFileName(testFileNoExt));
+        myCodeInsightFixture.complete(CompletionType.BASIC, 2);
+        if (LookupManager.getActiveLookup(myCodeInsightFixture.getEditor()) != null) {
+            myCodeInsightFixture.type('\n');
+        }
+    }
+
+    public void checkResultByFile(final String testFileNoExt, final JsonOrYaml fileKind) {
+        myCodeInsightFixture.checkResultByFile(fileKind.getFileName(testFileNoExt));
     }
 
     public enum JsonOrYaml {

--- a/src/test/resources/testing/insert/field_array.json
+++ b/src/test/resources/testing/insert/field_array.json
@@ -1,0 +1,4 @@
+{
+  "swagger": "2.0",
+  pro<caret>
+}

--- a/src/test/resources/testing/insert/field_array.yaml
+++ b/src/test/resources/testing/insert/field_array.yaml
@@ -1,0 +1,2 @@
+swagger: 2.0
+pro<caret>

--- a/src/test/resources/testing/insert/field_array_after.json
+++ b/src/test/resources/testing/insert/field_array_after.json
@@ -1,0 +1,6 @@
+{
+  "swagger": "2.0",
+  "produces": [
+    <caret>
+  ]
+}

--- a/src/test/resources/testing/insert/field_array_after.yaml
+++ b/src/test/resources/testing/insert/field_array_after.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+produces:
+  - <caret>

--- a/src/test/resources/testing/insert/field_object.json
+++ b/src/test/resources/testing/insert/field_object.json
@@ -1,0 +1,4 @@
+{
+  "swagger": "2.0",
+  inf<caret>
+}

--- a/src/test/resources/testing/insert/field_object.yaml
+++ b/src/test/resources/testing/insert/field_object.yaml
@@ -1,0 +1,2 @@
+swagger: 2.0
+inf<caret>

--- a/src/test/resources/testing/insert/field_object_after.json
+++ b/src/test/resources/testing/insert/field_object_after.json
@@ -1,0 +1,6 @@
+{
+  "swagger": "2.0",
+  "info": {
+    <caret>
+  }
+}

--- a/src/test/resources/testing/insert/field_object_after.yaml
+++ b/src/test/resources/testing/insert/field_object_after.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+info:
+  <caret>

--- a/src/test/resources/testing/insert/field_string.json
+++ b/src/test/resources/testing/insert/field_string.json
@@ -1,0 +1,4 @@
+{
+  "swagger": "2.0",
+  base<caret>
+}

--- a/src/test/resources/testing/insert/field_string.yaml
+++ b/src/test/resources/testing/insert/field_string.yaml
@@ -1,0 +1,2 @@
+swagger: 2.0
+base<caret>

--- a/src/test/resources/testing/insert/field_string_after.json
+++ b/src/test/resources/testing/insert/field_string_after.json
@@ -1,0 +1,4 @@
+{
+  "swagger": "2.0",
+  "basePath": "<caret>"
+}

--- a/src/test/resources/testing/insert/field_string_after.yaml
+++ b/src/test/resources/testing/insert/field_string_after.yaml
@@ -1,0 +1,2 @@
+swagger: 2.0
+basePath: <caret>


### PR DESCRIPTION
Better user experience with insert handlers:
- If an object type field is auto completed, object block is generated
  and caret is moved into the object
- If a string type field is auto completed, empty string value is generated
  and caret is moved to start of the string value
- If an array type field is auto completed, empty array is generated
  and caret is moved into the array

Fixes #10
