### PR TITLE
Ignore YAML merge and anchor keys validation

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/annotator/JsonValidKeyAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/JsonValidKeyAnnotator.java
@@ -9,7 +9,7 @@ import org.zalando.intellij.swagger.intention.field.RemoveJsonFieldIntentionActi
 import org.zalando.intellij.swagger.traversal.JsonTraversal;
 import org.zalando.intellij.swagger.traversal.path.MainPathResolver;
 import org.zalando.intellij.swagger.validator.field.FieldsValidator;
-import org.zalando.intellij.swagger.validator.field.UnknownKeyValidator;
+import org.zalando.intellij.swagger.validator.field.UnknownJsonKeyValidator;
 
 public class JsonValidKeyAnnotator implements Annotator {
 
@@ -19,8 +19,7 @@ public class JsonValidKeyAnnotator implements Annotator {
         if (new FileDetector().isMainSwaggerJsonFile(psiElement.getContainingFile())) {
             final FieldsValidator fieldsValidator = new FieldsValidator(new JsonTraversal(),
                     new MainPathResolver(),
-                    new UnknownKeyValidator(
-                            new RemoveJsonFieldIntentionAction(psiElement)));
+                    new UnknownJsonKeyValidator(new RemoveJsonFieldIntentionAction(psiElement)));
 
             fieldsValidator.validate(psiElement, annotationHolder);
         }

--- a/src/main/java/org/zalando/intellij/swagger/annotator/YamlValidKeyAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/YamlValidKeyAnnotator.java
@@ -6,10 +6,10 @@ import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.file.FileDetector;
 import org.zalando.intellij.swagger.intention.field.RemoveYamlFieldIntentionAction;
-import org.zalando.intellij.swagger.traversal.path.MainPathResolver;
 import org.zalando.intellij.swagger.traversal.YamlTraversal;
+import org.zalando.intellij.swagger.traversal.path.MainPathResolver;
 import org.zalando.intellij.swagger.validator.field.FieldsValidator;
-import org.zalando.intellij.swagger.validator.field.UnknownKeyValidator;
+import org.zalando.intellij.swagger.validator.field.UnknownYamlKeyValidator;
 
 public class YamlValidKeyAnnotator implements Annotator {
 
@@ -17,11 +17,13 @@ public class YamlValidKeyAnnotator implements Annotator {
     public void annotate(@NotNull final PsiElement psiElement, @NotNull final AnnotationHolder annotationHolder) {
 
         if (new FileDetector().isMainSwaggerYamlFile(psiElement.getContainingFile())) {
+            final YamlTraversal yamlTraversal = new YamlTraversal();
+
             final FieldsValidator fieldsValidator = new FieldsValidator(
-                    new YamlTraversal(),
+                    yamlTraversal,
                     new MainPathResolver(),
-                    new UnknownKeyValidator(
-                            new RemoveYamlFieldIntentionAction(psiElement)));
+                    new UnknownYamlKeyValidator(new RemoveYamlFieldIntentionAction(psiElement), yamlTraversal)
+            );
 
             fieldsValidator.validate(psiElement, annotationHolder);
         }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/YamlTraversal.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/YamlTraversal.java
@@ -25,11 +25,24 @@ public class YamlTraversal extends Traversal {
 
     @Override
     public Optional<String> getKeyNameIfKey(final PsiElement psiElement) {
-        return Optional.ofNullable(psiElement.getParent())
+        return getAsYamlKeyValue(psiElement)
+                .map(YAMLKeyValue::getKeyText);
+    }
+
+    public boolean isAnchorKey(final PsiElement psiElement) {
+        return getAsYamlKeyValue(psiElement)
+                .map(YAMLKeyValue::getValue)
+                .map(YAMLValue::getText)
+                .filter(value -> value.startsWith("&"))
+                .isPresent();
+    }
+
+    private Optional<YAMLKeyValue> getAsYamlKeyValue(final PsiElement psiElement) {
+        return Optional.ofNullable(psiElement)
+                .map(PsiElement::getParent)
                 .filter(el -> el instanceof YAMLKeyValue)
                 .map(YAMLKeyValue.class::cast)
-                .filter(value -> value.getKey() == psiElement)
-                .map(YAMLKeyValue::getKeyText);
+                .filter(value -> value.getKey() == psiElement);
     }
 
     @Override
@@ -293,4 +306,13 @@ public class YamlTraversal extends Traversal {
                         .isPresent();
     }
 
+    public boolean isChildOfAnchorKey(final PsiElement psiElement) {
+        if (isAnchorKey(extractObjectForValidation(psiElement))) {
+            return true;
+        }
+
+        final PsiElement parent = psiElement.getParent();
+
+        return parent != null && isChildOfAnchorKey(parent);
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/validator/field/UnknownJsonKeyValidator.java
+++ b/src/main/java/org/zalando/intellij/swagger/validator/field/UnknownJsonKeyValidator.java
@@ -1,0 +1,30 @@
+package org.zalando.intellij.swagger.validator.field;
+
+import com.google.common.collect.ImmutableSet;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.psi.PsiElement;
+import org.zalando.intellij.swagger.completion.field.model.Field;
+
+import java.util.List;
+import java.util.Set;
+
+public class UnknownJsonKeyValidator extends UnknownKeyValidator {
+
+    private static final String VENDOR_EXTENSION_PREFIX = "x-";
+    private static final Set<String> IGNORED_KEY_PREFIXES = ImmutableSet.of(VENDOR_EXTENSION_PREFIX);
+
+    public UnknownJsonKeyValidator(final IntentionAction intentionAction) {
+        super(intentionAction);
+    }
+
+    @Override
+    protected boolean isInvalid(final String key, final List<Field> availableKeys) {
+        return availableKeys.stream().noneMatch(field -> field.getName().equals(key));
+    }
+
+    @Override
+    protected boolean shouldIgnore(final String key, final PsiElement element) {
+        return IGNORED_KEY_PREFIXES.stream().anyMatch(key::startsWith);
+    }
+
+}

--- a/src/main/java/org/zalando/intellij/swagger/validator/field/UnknownKeyValidator.java
+++ b/src/main/java/org/zalando/intellij/swagger/validator/field/UnknownKeyValidator.java
@@ -8,24 +8,29 @@ import org.zalando.intellij.swagger.completion.field.model.Field;
 
 import java.util.List;
 
-public class UnknownKeyValidator {
-
-    private static final String VENDOR_EXTENSION_PREFIX = "x-";
+abstract class UnknownKeyValidator {
 
     private final IntentionAction intentionAction;
 
-    public UnknownKeyValidator(final IntentionAction intentionAction) {
+    UnknownKeyValidator(final IntentionAction intentionAction) {
         this.intentionAction = intentionAction;
     }
 
     void validate(final String key,
-                         final List<Field> availableKeys,
-                         final PsiElement psiElement,
-                         final AnnotationHolder annotationHolder) {
-        boolean keyFoundInAvailableKeys = availableKeys.stream().anyMatch(field -> field.getName().equals(key));
-        if (!keyFoundInAvailableKeys && !key.startsWith(VENDOR_EXTENSION_PREFIX)) {
+                  final List<Field> availableKeys,
+                  final PsiElement psiElement,
+                  final AnnotationHolder annotationHolder) {
+        if (shouldIgnore(key, psiElement)) {
+            return;
+        }
+
+        if (isInvalid(key, availableKeys)) {
             final Annotation errorAnnotation = annotationHolder.createErrorAnnotation(psiElement, "Invalid key");
             errorAnnotation.registerFix(intentionAction);
         }
     }
+
+    abstract boolean isInvalid(final String key, final List<Field> availableKeys);
+
+    abstract boolean shouldIgnore(final String key, final PsiElement psiElement);
 }

--- a/src/main/java/org/zalando/intellij/swagger/validator/field/UnknownYamlKeyValidator.java
+++ b/src/main/java/org/zalando/intellij/swagger/validator/field/UnknownYamlKeyValidator.java
@@ -1,0 +1,40 @@
+package org.zalando.intellij.swagger.validator.field;
+
+import com.google.common.collect.ImmutableSet;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.psi.PsiElement;
+import org.zalando.intellij.swagger.completion.field.model.Field;
+import org.zalando.intellij.swagger.traversal.YamlTraversal;
+
+import java.util.List;
+import java.util.Set;
+
+public class UnknownYamlKeyValidator extends UnknownKeyValidator {
+
+    private static final String VENDOR_EXTENSION_PREFIX = "x-";
+    private static final String MERGE_KEY = "<<";
+
+    private static final Set<String> IGNORED_KEY_PREFIXES = ImmutableSet.of(VENDOR_EXTENSION_PREFIX);
+    private static final Set<String> IGNORED_KEYS = ImmutableSet.of(MERGE_KEY);
+
+    private final YamlTraversal yamlTraversal;
+
+    public UnknownYamlKeyValidator(final IntentionAction intentionAction, final YamlTraversal yamlTraversal) {
+        super(intentionAction);
+        this.yamlTraversal = yamlTraversal;
+    }
+
+    @Override
+    protected boolean isInvalid(final String key, final List<Field> availableKeys) {
+        return availableKeys.stream().noneMatch(field -> field.getName().equals(key));
+    }
+
+    @Override
+    protected boolean shouldIgnore(final String key, final PsiElement element) {
+        return IGNORED_KEY_PREFIXES.stream().anyMatch(key::startsWith) ||
+                IGNORED_KEYS.stream().anyMatch(key::equals) ||
+                yamlTraversal.isAnchorKey(element) ||
+                yamlTraversal.isChildOfAnchorKey(element);
+    }
+
+}

--- a/src/test/resources/testing/validator/no_errors.yaml
+++ b/src/test/resources/testing/validator/no_errors.yaml
@@ -53,6 +53,10 @@ paths:
         - "application/json"
         - "text/html"
       responses:
+        Default: &default_response
+          400:
+            description: "default response",
+        <<: *default_response
         200:
           description: "pet response"
           schema:
@@ -72,10 +76,6 @@ paths:
                   format": int32
                 name:
                   type: string
-        default:
-          description: "error payload"
-          schema:
-            $ref: "#/definitions/ErrorModel"
 securityDefinitions:
   githubAccessCode:
     type: "oauth2"


### PR DESCRIPTION
Exclude YAML merge and anchor keys when validating Swagger keys.

Fixes #87