### PR TITLE
the format property is an open string-valued property, and can have a…

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/completion/value/model/Values.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/value/model/Values.java
@@ -54,7 +54,9 @@ public class Values {
                 new StringValue("binary"),
                 new StringValue("date"),
                 new StringValue("date-time"),
-                new StringValue("password")
+                new StringValue("password"),
+                new StringValue("email"),
+                new StringValue("uuid")
         );
     }
 


### PR DESCRIPTION
This PR introduce some common know string formats for the completion engine. They came explicitly from the documentation:

```... the format property is an open string-valued property, and can have any value to support documentation needs. Formats such as "email", "uuid", etc., can be used even though they are not defined by this specification ... ```