### PR TITLE
Improved YAML value auto completion with quotes

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/insert/YamlInsertValueHandler.java
+++ b/src/main/java/org/zalando/intellij/swagger/insert/YamlInsertValueHandler.java
@@ -8,34 +8,75 @@ import org.apache.commons.lang.StringUtils;
 
 public class YamlInsertValueHandler implements InsertHandler<LookupElement> {
 
+    private static final char SINGLE_QUOTE = '\'';
+    private static final char DOUBLE_QUOTE = '"';
+
     private static final char[] RESERVED_YAML_CHARS = {
             ':', '{', '}', '[', ']', ',', '&', '*', '#', '?', '|', '-', '<', '>', '=', '!', '%', '@', '`'
     };
 
     @Override
     public void handleInsert(final InsertionContext insertionContext, final LookupElement lookupElement) {
-        if (StringUtils.containsAny(lookupElement.getLookupString(), RESERVED_YAML_CHARS)) {
-            handleEndingQuote(insertionContext);
-            handleStartingQuote(insertionContext, lookupElement);
+        if (shouldUseQuotes(lookupElement)) {
+            final boolean hasDoubleQuotes = hasStartingOrEndingQuoteOfType(insertionContext, lookupElement, DOUBLE_QUOTE);
+
+            if (hasDoubleQuotes) {
+                handleEndingQuote(insertionContext, DOUBLE_QUOTE);
+                handleStartingQuote(insertionContext, lookupElement, DOUBLE_QUOTE);
+            } else {
+                handleEndingQuote(insertionContext, SINGLE_QUOTE);
+                handleStartingQuote(insertionContext, lookupElement, SINGLE_QUOTE);
+            }
         }
     }
 
-    private void handleStartingQuote(final InsertionContext insertionContext, final LookupElement lookupElement) {
+    private boolean shouldUseQuotes(final LookupElement lookupElement) {
+        return StringUtils.containsAny(lookupElement.getLookupString(), RESERVED_YAML_CHARS);
+    }
+
+    private boolean hasStartingOrEndingQuoteOfType(final InsertionContext insertionContext,
+                                                   final LookupElement lookupElement,
+                                                   final char quoteType) {
         final int caretOffset = insertionContext.getEditor().getCaretModel().getOffset();
         final int startOfLookupStringOffset = caretOffset - lookupElement.getLookupString().length();
-        final boolean hasStartingQuote = insertionContext.getDocument().getText().charAt(startOfLookupStringOffset - 1) == '\'';
+
+
+        final boolean hasStartingQuote = hasStartingQuote(insertionContext, quoteType, startOfLookupStringOffset);
+        final boolean hasEndingQuote = hasEndingQuote(insertionContext, caretOffset, quoteType);
+
+        return hasStartingQuote || hasEndingQuote;
+    }
+
+    private boolean hasEndingQuote(final InsertionContext insertionContext, final int caretOffset, final char quoteType) {
+        final CharSequence chars = insertionContext.getDocument().getCharsSequence();
+
+        return CharArrayUtil.regionMatches(chars, caretOffset, String.valueOf(quoteType));
+    }
+
+    private boolean hasStartingQuote(final InsertionContext insertionContext, final char quoteType, final int startOfLookupStringOffset) {
+        return insertionContext.getDocument().getText().charAt(startOfLookupStringOffset - 1) == quoteType;
+    }
+
+    private void handleStartingQuote(final InsertionContext insertionContext,
+                                     final LookupElement lookupElement,
+                                     final char quoteType) {
+        final int caretOffset = insertionContext.getEditor().getCaretModel().getOffset();
+        final int startOfLookupStringOffset = caretOffset - lookupElement.getLookupString().length();
+
+        final boolean hasStartingQuote = hasStartingQuote(insertionContext, quoteType, startOfLookupStringOffset);
+
         if (!hasStartingQuote) {
-            insertionContext.getDocument().insertString(startOfLookupStringOffset, "'");
+            insertionContext.getDocument().insertString(startOfLookupStringOffset, String.valueOf(quoteType));
         }
     }
 
-    private void handleEndingQuote(final InsertionContext insertionContext) {
+    private void handleEndingQuote(final InsertionContext insertionContext, final char quoteType) {
         final int caretOffset = insertionContext.getEditor().getCaretModel().getOffset();
-        final CharSequence chars = insertionContext.getDocument().getCharsSequence();
 
-        final boolean hasEndingQuote = CharArrayUtil.regionMatches(chars, caretOffset, "'");
+        final boolean hasEndingQuote = hasEndingQuote(insertionContext, caretOffset, quoteType);
+
         if (!hasEndingQuote) {
-            insertionContext.getDocument().insertString(caretOffset, "'");
+            insertionContext.getDocument().insertString(caretOffset, String.valueOf(quoteType));
         }
     }
 }

--- a/src/test/java/org/zalando/intellij/swagger/insert/InsertValueTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/insert/InsertValueTest.java
@@ -38,7 +38,7 @@ public class InsertValueTest extends JsonAndYamlCompletionTest {
     }
 
     @Test
-    public void thatValueInsideQuotesIsHandled() {
+    public void thatValueInsideSingleQuotesIsHandled() {
         completeAndCheckResultsByFile("value_inside_quotes", "value_inside_quotes_after");
     }
 

--- a/src/test/java/org/zalando/intellij/swagger/insert/InsertYamlValueTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/insert/InsertYamlValueTest.java
@@ -1,0 +1,35 @@
+package org.zalando.intellij.swagger.insert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.zalando.intellij.swagger.completion.JsonAndYamlCompletionTest;
+import org.zalando.intellij.swagger.fixture.Format;
+
+@RunWith(Parameterized.class)
+public class InsertYamlValueTest extends JsonAndYamlCompletionTest {
+
+    public InsertYamlValueTest(Format format) {
+        super(format, "testing/insert/value/yaml");
+    }
+
+    @Parameterized.Parameters(name = "inputKind: {0}")
+    public static Object[] parameters() {
+        return new Object[]{Format.YAML};
+    }
+
+    @Test
+    public void thatValueInsideDoubleQuotesIsHandled() {
+        completeAndCheckResultsByFile("value_inside_double_quotes");
+    }
+
+    @Test
+    public void thatValueStartingWithDoubleQuoteIsHandled() {
+        completeAndCheckResultsByFile("value_starting_with_double_quote");
+    }
+
+    @Test
+    public void thatValueEndingWithDoubleQuoteIsHandled() {
+        completeAndCheckResultsByFile("value_ending_with_double_quote");
+    }
+}

--- a/src/test/resources/testing/insert/value/yaml/value_ending_with_double_quote.yaml
+++ b/src/test/resources/testing/insert/value/yaml/value_ending_with_double_quote.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+consumes:
+  - <caret>"

--- a/src/test/resources/testing/insert/value/yaml/value_ending_with_double_quote_after.yaml
+++ b/src/test/resources/testing/insert/value/yaml/value_ending_with_double_quote_after.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+consumes:
+  - "*/*"

--- a/src/test/resources/testing/insert/value/yaml/value_inside_double_quotes.yaml
+++ b/src/test/resources/testing/insert/value/yaml/value_inside_double_quotes.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+consumes:
+  - "<caret>"

--- a/src/test/resources/testing/insert/value/yaml/value_inside_double_quotes_after.yaml
+++ b/src/test/resources/testing/insert/value/yaml/value_inside_double_quotes_after.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+consumes:
+  - "*/*"

--- a/src/test/resources/testing/insert/value/yaml/value_starting_with_double_quote.yaml
+++ b/src/test/resources/testing/insert/value/yaml/value_starting_with_double_quote.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+consumes:
+  - "<caret>

--- a/src/test/resources/testing/insert/value/yaml/value_starting_with_double_quote_after.yaml
+++ b/src/test/resources/testing/insert/value/yaml/value_starting_with_double_quote_after.yaml
@@ -1,0 +1,3 @@
+swagger: 2.0
+consumes:
+  - "*/*"


### PR DESCRIPTION
Handle single and double quotes when auto completion
is used for YAML values.

Fixes #95