### PR TITLE
Improved Swagger UI usability

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/file/FileContentManipulator.java
+++ b/src/main/java/org/zalando/intellij/swagger/file/FileContentManipulator.java
@@ -1,5 +1,7 @@
 package org.zalando.intellij.swagger.file;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -7,13 +9,31 @@ import java.nio.file.Files;
 
 public class FileContentManipulator {
 
-    void setPlaceholderValue(final String placeholderName, final String value, final File file) {
+    private static final String SPEC_START_TOKEN = "/*intellij-swagger-spec-start*/";
+    private static final String SPEC_END_TOKEN = "/*intellij-swagger-spec-end*/";
+
+    void setJsonToIndexFile(final String specJson, final File indexFile) {
         try {
-            String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
-            content = content.replace(placeholderName, value);
-            Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+            final String originalContent = new String(Files.readAllBytes(indexFile.toPath()), StandardCharsets.UTF_8);
+            final String newContent = insertContentBetween(specJson, originalContent, SPEC_START_TOKEN, SPEC_END_TOKEN);
+
+            Files.write(indexFile.toPath(), newContent.getBytes(StandardCharsets.UTF_8));
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @NotNull
+    private String insertContentBetween(final String contentToBeInserted,
+                                        final String originalContent,
+                                        final String startToken,
+                                        final String endToken) {
+        final int startIndex = originalContent.indexOf(startToken) + startToken.length();
+        final int endIndex = originalContent.indexOf(endToken);
+
+        final String before = originalContent.substring(0, startIndex);
+        final String end = originalContent.substring(endIndex);
+
+        return before + contentToBeInserted + end;
     }
 }

--- a/src/main/resources/swagger-ui/index.html
+++ b/src/main/resources/swagger-ui/index.html
@@ -71,10 +71,10 @@
 <script src="./swagger-ui-standalone-preset.js"> </script>
 <script>
 window.onload = function() {
-  
+
   // Build a system
   const ui = SwaggerUIBundle({
-    spec: ${swaggerSpecification},
+    spec: /*intellij-swagger-spec-start*//*intellij-swagger-spec-end*/,
     validatorUrl: null,
     dom_id: '#swagger-ui',
     presets: [

--- a/src/test/java/org/zalando/intellij/swagger/file/FileContentManipulatorTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/file/FileContentManipulatorTest.java
@@ -29,7 +29,7 @@ public class FileContentManipulatorTest {
         File targetFile = copyResourceTo("with_placeholder.html", "index.html");
         File expectedOutputFile = copyResourceTo("with_placeholder_replaced.html", "expected.html");
 
-        fileContentManipulator.setPlaceholderValue("${swaggerSpecification}", "http://petstore.swagger.io/v2/swagger.json", targetFile);
+        fileContentManipulator.setJsonToIndexFile("{}", targetFile);
 
         assertTrue("The files differ!", FileUtils.contentEquals(targetFile, expectedOutputFile));
 

--- a/src/test/resources/testing/file/with_placeholder.html
+++ b/src/test/resources/testing/file/with_placeholder.html
@@ -6,7 +6,19 @@
 </head>
 <body>
 
-<h1>spec: ${swaggerSpecification}</h1>
+const ui = SwaggerUIBundle({
+spec: /*intellij-swagger-spec-start*/${swaggerSpecification}/*intellij-swagger-spec-end*/,
+validatorUrl: null,
+dom_id: '#swagger-ui',
+presets: [
+SwaggerUIBundle.presets.apis,
+SwaggerUIStandalonePreset
+],
+plugins: [
+SwaggerUIBundle.plugins.DownloadUrl
+],
+layout: "StandaloneLayout"
+})
 
 </body>
 </html>

--- a/src/test/resources/testing/file/with_placeholder_replaced.html
+++ b/src/test/resources/testing/file/with_placeholder_replaced.html
@@ -6,7 +6,19 @@
 </head>
 <body>
 
-<h1>spec: http://petstore.swagger.io/v2/swagger.json</h1>
+const ui = SwaggerUIBundle({
+spec: /*intellij-swagger-spec-start*/{}/*intellij-swagger-spec-end*/,
+validatorUrl: null,
+dom_id: '#swagger-ui',
+presets: [
+SwaggerUIBundle.presets.apis,
+SwaggerUIStandalonePreset
+],
+plugins: [
+SwaggerUIBundle.plugins.DownloadUrl
+],
+layout: "StandaloneLayout"
+})
 
 </body>
 </html>


### PR DESCRIPTION
It is no longer necessary to click the browser icon in the
editor in order to view an updated Swagger UI. When a Swagger file
is saved the Swagger UI file is updated; it is only necessary to
reload the browser page after a file save.

Fixes #65