### PR TITLE
Fixed Swagger UI caching

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/ui/SwaggerUiUrlProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/SwaggerUiUrlProvider.java
@@ -74,14 +74,16 @@ public class SwaggerUiUrlProvider extends BuiltInWebBrowserUrlProvider implement
     @Nullable
     @Override
     protected Url getUrl(@NotNull OpenInBrowserRequest request, @NotNull VirtualFile file) throws BrowserException {
-        if (indexFileExists()) {
-            return swaggerUiIndexFile;
-        }
+        final String specificationContentAsJson = getSpecificationContentAsJson(request.getFile());
 
-        swaggerUiIndexFile = swaggerUiCreator.createSwaggerUiFiles(getSpecificationContentAsJson(request.getFile()))
-                .map(swaggerUiFolderPath ->
-                        new LocalFileUrl(swaggerUiFolderPath + File.separator + "index.html"))
-                .orElse(null);
+        if (indexFileExists()) {
+            swaggerUiCreator.updateSwaggerUiFile(swaggerUiIndexFile, specificationContentAsJson);
+        } else {
+            swaggerUiIndexFile = swaggerUiCreator.createSwaggerUiFiles(specificationContentAsJson)
+                    .map(swaggerUiFolderPath ->
+                            new LocalFileUrl(swaggerUiFolderPath + File.separator + "index.html"))
+                    .orElse(null);
+        }
 
         return swaggerUiIndexFile;
     }


### PR DESCRIPTION
This commit improves the way Swagger UI is rendered.

- If the user clicks the browser icon the Swagger UI is always re-rendered
- If the user saves a file, the Swagger UI is re-rendered on the fly

This makes it easier to work with multiple Swagger files using the Swagger UI.

Fixes #107