### PR TITLE
Issue-129: Fix URL formatting on Windows

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/ui/components/SwaggerUIViewer.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/components/SwaggerUIViewer.java
@@ -56,7 +56,7 @@ public class SwaggerUIViewer extends JPanel {
 
         @Override
         public void swaggerHTMLFilesChanged(Url indexUrl) {
-            Platform.runLater(() -> webEngine.load("file://" + indexUrl.toExternalForm()));
+            Platform.runLater(() -> webEngine.load("file:///" + indexUrl.toExternalForm()));
         }
     }
 }


### PR DESCRIPTION
Fix for https://github.com/zalando/intellij-swagger/issues/129

The file protocol requires three slashes if it's to be used against actual file paths. This just worked on mac OSX and Linux because them file paths start with a / :muscle: 

Tested on Windows and Linux and seems good now.