### PR TITLE
Fixed embedded Swagger UI with multiple files

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/ui/actions/SwaggerUIFilesChangeNotifier.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/actions/SwaggerUIFilesChangeNotifier.java
@@ -1,11 +1,12 @@
 package org.zalando.intellij.swagger.ui.actions;
 
-import com.intellij.util.Url;
-import com.intellij.util.messages.Topic;
+import com.intellij.openapi.vfs.*;
+import com.intellij.util.*;
+import com.intellij.util.messages.*;
 
 public interface SwaggerUIFilesChangeNotifier {
 
     Topic<SwaggerUIFilesChangeNotifier> SWAGGER_UI_FILES_CHANGED = Topic.create("Swagger UI Files", SwaggerUIFilesChangeNotifier.class);
 
-    void swaggerHTMLFilesChanged(Url indexUrl);
+    void swaggerHTMLFilesChanged(VirtualFile updatedFile, Url indexUrl);
 }

--- a/src/main/java/org/zalando/intellij/swagger/ui/components/SwaggerUIViewer.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/components/SwaggerUIViewer.java
@@ -1,6 +1,7 @@
 package org.zalando.intellij.swagger.ui.components;
 
 import com.intellij.openapi.application.*;
+import com.intellij.openapi.vfs.*;
 import com.intellij.ui.*;
 import com.intellij.util.*;
 import com.intellij.util.messages.*;
@@ -19,9 +20,11 @@ public class SwaggerUIViewer extends JPanel {
     private WebEngine webEngine;
     private MessageBus messageBus;
     private MessageBusConnection messageBusConnection;
+    private final VirtualFile file;
 
-    public SwaggerUIViewer() {
+    public SwaggerUIViewer(final VirtualFile file) {
         super(new BorderLayout());
+        this.file = file;
         this.setBackground(JBColor.background());
         this.setVisible(false);
         Platform.setImplicitExit(false);
@@ -65,8 +68,10 @@ public class SwaggerUIViewer extends JPanel {
     class SwaggerUIUpdater implements SwaggerUIFilesChangeNotifier {
 
         @Override
-        public void swaggerHTMLFilesChanged(Url indexUrl) {
-            Platform.runLater(() -> webEngine.load("file:///" + indexUrl.toExternalForm()));
+        public void swaggerHTMLFilesChanged(final VirtualFile updatedFile, Url indexUrl) {
+            if (file.equals(updatedFile)) {
+                Platform.runLater(() -> webEngine.load("file:///" + indexUrl.toExternalForm()));
+            }
         }
     }
 }

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUIEditorProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUIEditorProvider.java
@@ -38,9 +38,10 @@ public class SwaggerUIEditorProvider implements FileEditorProvider {
     @Override
     public FileEditor createEditor(@NotNull final Project project, @NotNull final VirtualFile file) {
         FileEditor fileEditor = editorProvider.createEditor(project, file);
+
         return new SwaggerUISplitView(
                 (TextEditor) fileEditor,
-                new SwaggerUIViewer()
+                new SwaggerUIViewer(file)
         );
     }
 


### PR DESCRIPTION
Embedded Swagger UI showed the same UI when there were multiple Swagger files opened.
Only the most recent save was used for the UI.

This commit fixes the issue.

Fixes #137