### PR TITLE
Add support for informational HTTP status codes

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/completion/field/model/common/CommonFields.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/field/model/common/CommonFields.java
@@ -51,6 +51,11 @@ public class CommonFields {
     public static List<Field> responses() {
         return ImmutableList.of(
                 new ObjectField("default"),
+                
+                new ResponseField("100"),
+                new ResponseField("101"),
+                new ResponseField("102"), 
+            
                 new ResponseField("200"),
                 new ResponseField("201"),
                 new ResponseField("202"),

--- a/src/test/java/org/zalando/intellij/swagger/completion/field/completion/openapi/OpenApiCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/field/completion/openapi/OpenApiCompletionTest.java
@@ -149,7 +149,7 @@ public class OpenApiCompletionTest extends JsonAndYamlCompletionTest {
     public void thatResponsesKeysAreSuggested() {
         getCaretCompletions("responses")
                 .assertContains("default", "200", "201")
-                .isOfSize(59);
+                .isOfSize(62);
     }
 
     @Test

--- a/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
@@ -161,7 +161,7 @@ public class SwaggerCompletionTest extends JsonAndYamlCompletionTest {
     public void thatResponsesKeysAreSuggested() {
         getCaretCompletions("responses")
                 .assertContains("default", "200", "201")
-                .isOfSize(59);
+                .isOfSize(62);
     }
 
     @Test

--- a/src/test/resources/testing/insert/field/response_after.json
+++ b/src/test/resources/testing/insert/field/response_after.json
@@ -4,7 +4,7 @@
     "/pets": {
       "get": {
         "responses": {
-          "200": {
+          "100": {
             "description": "<caret>"
           }
         }

--- a/src/test/resources/testing/insert/field/response_after.yaml
+++ b/src/test/resources/testing/insert/field/response_after.yaml
@@ -3,5 +3,5 @@ paths:
   /pets: 
     get: 
       responses: 
-        200:
+        100:
           description: <caret>


### PR DESCRIPTION
I see no obvious reason these should not be included.  Please, correct me if I'm wrong (:

100 and 101 are defined here: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
And 102 here: https://tools.ietf.org/html/rfc2518#section-10.1

