### PR TITLE
Added support to informational HTTP status codes (100, 101, 102).

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/completion/field/model/common/CommonFields.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/field/model/common/CommonFields.java
@@ -51,6 +51,10 @@ public class CommonFields {
     public static List<Field> responses() {
         return ImmutableList.of(
                 new ObjectField("default"),
+                new ResponseField("100"),
+                new ResponseField("101"),
+                new ResponseField("102"),
+
                 new ResponseField("200"),
                 new ResponseField("201"),
                 new ResponseField("202"),

--- a/src/test/java/org/zalando/intellij/swagger/completion/field/completion/openapi/OpenApiCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/field/completion/openapi/OpenApiCompletionTest.java
@@ -149,7 +149,7 @@ public class OpenApiCompletionTest extends JsonAndYamlCompletionTest {
     public void thatResponsesKeysAreSuggested() {
         getCaretCompletions("responses")
                 .assertContains("default", "200", "201")
-                .isOfSize(59);
+                .isOfSize(62);
     }
 
     @Test

--- a/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
@@ -161,7 +161,7 @@ public class SwaggerCompletionTest extends JsonAndYamlCompletionTest {
     public void thatResponsesKeysAreSuggested() {
         getCaretCompletions("responses")
                 .assertContains("default", "200", "201")
-                .isOfSize(59);
+                .isOfSize(62);
     }
 
     @Test

--- a/src/test/resources/testing/insert/field/response_after.json
+++ b/src/test/resources/testing/insert/field/response_after.json
@@ -4,7 +4,7 @@
     "/pets": {
       "get": {
         "responses": {
-          "200": {
+          "100": {
             "description": "<caret>"
           }
         }

--- a/src/test/resources/testing/insert/field/response_after.yaml
+++ b/src/test/resources/testing/insert/field/response_after.yaml
@@ -3,5 +3,5 @@ paths:
   /pets: 
     get: 
       responses: 
-        200:
+        100:
           description: <caret>


### PR DESCRIPTION
Second attempt at https://github.com/zalando/intellij-swagger/pull/147 (:
I messed up with branches and commits and couldn't figure out how to squash everything into one commit.

All tests pass, but you may want to look at the changes a bit more thoroughly — it's my first interaction with Java ever, so I may have done something dumb.