### PR TITLE
Fixed schema completions in referenced files

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionPathResolver.java
@@ -5,8 +5,12 @@ import com.intellij.psi.PsiElement;
 public class DefinitionPathResolver implements PathResolver {
 
     @Override
-    public final boolean childOfDefinitions(final PsiElement psiElement) {
+    public final boolean childOfSchema(final PsiElement psiElement) {
         return hasPath(psiElement, "$");
     }
 
+    @Override
+    public final boolean childOfSchemaItems(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.items");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsInRootPathResolver.java
@@ -5,8 +5,12 @@ import com.intellij.psi.PsiElement;
 public class DefinitionsInRootPathResolver implements PathResolver {
 
     @Override
-    public final boolean childOfDefinitions(final PsiElement psiElement) {
+    public final boolean childOfSchema(final PsiElement psiElement) {
         return hasPath(psiElement, "$.*");
     }
 
+    @Override
+    public final boolean childOfSchemaItems(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.items");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsNotInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsNotInRootPathResolver.java
@@ -5,8 +5,12 @@ import com.intellij.psi.PsiElement;
 public class DefinitionsNotInRootPathResolver implements PathResolver {
 
     @Override
-    public final boolean childOfDefinitions(final PsiElement psiElement) {
+    public final boolean childOfSchema(final PsiElement psiElement) {
         return hasPath(psiElement, "$.*.*");
     }
 
+    @Override
+    public final boolean childOfSchemaItems(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.items");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
@@ -32,12 +32,6 @@ public class MainPathResolver implements PathResolver {
         return hasPath(psiElement, "$.paths.*.*") && !childOfParameters(psiElement);
     }
 
-    public final boolean childOfExternalDocs(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.externalDocs") ||
-                hasPath(psiElement, "$.paths.*.*.externalDocs") ||
-                hasPath(psiElement, "$.**.schema.externalDocs");
-    }
-
     public final boolean childOfParameters(final PsiElement psiElement) {
         return hasPath(psiElement, "$.paths.*.*.parameters") ||
                 hasPath(psiElement, "$.paths.*.parameters");
@@ -86,14 +80,6 @@ public class MainPathResolver implements PathResolver {
                 hasPath(psiElement, "$.definitions.**.items");
     }
 
-    public final boolean childOfPropertiesSchema(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.properties.*");
-    }
-
-    public final boolean childOfAdditionalProperties(PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.additionalProperties");
-    }
-
     public final boolean childOfXml(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.schema.xml");
     }
@@ -112,30 +98,6 @@ public class MainPathResolver implements PathResolver {
                 hasPath(psiElement, "$.paths.*.*.consumes") ||
                 hasPath(psiElement, "$.paths.*.*.produces");
 
-    }
-
-    public final boolean isFormatValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.format");
-    }
-
-    public final boolean isTypeValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.type");
-    }
-
-    public final boolean isInValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.in");
-    }
-
-    public final boolean isBooleanValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.deprecated") ||
-                hasPath(psiElement, "$.**.required") ||
-                hasPath(psiElement, "$.**.allowEmptyValue") ||
-                hasPath(psiElement, "$.**.exclusiveMaximum") ||
-                hasPath(psiElement, "$.**.exclusiveMinimum") ||
-                hasPath(psiElement, "$.**.uniqueItems") ||
-                hasPath(psiElement, "$.**.readOnly") ||
-                hasPath(psiElement, "$.**.attribute") ||
-                hasPath(psiElement, "$.**.wrapped");
     }
 
     public final boolean isSchemesValue(final PsiElement psiElement) {

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathDefinitionsInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathDefinitionsInRootPathResolver.java
@@ -12,11 +12,6 @@ public class PathDefinitionsInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*.*") && !childOfParameters(psiElement);
     }
 
-    public final boolean childOfExternalDocs(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.*.*.externalDocs") ||
-                hasPath(psiElement, "$.**.schema.externalDocs");
-    }
-
     public final boolean childOfParameters(final PsiElement psiElement) {
         return hasPath(psiElement, "$.*.*.parameters");
     }
@@ -51,14 +46,6 @@ public class PathDefinitionsInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.**.schema.items");
     }
 
-    public final boolean childOfPropertiesSchema(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.properties.*");
-    }
-
-    public final boolean childOfAdditionalProperties(PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.additionalProperties");
-    }
-
     public final boolean childOfXml(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.schema.xml");
     }
@@ -67,30 +54,6 @@ public class PathDefinitionsInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*.*.consumes") ||
                 hasPath(psiElement, "$.*.*.produces");
 
-    }
-
-    public final boolean isFormatValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.format");
-    }
-
-    public final boolean isTypeValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.type");
-    }
-
-    public final boolean isInValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.in");
-    }
-
-    public final boolean isBooleanValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.deprecated") ||
-                hasPath(psiElement, "$.**.required") ||
-                hasPath(psiElement, "$.**.allowEmptyValue") ||
-                hasPath(psiElement, "$.**.exclusiveMaximum") ||
-                hasPath(psiElement, "$.**.exclusiveMinimum") ||
-                hasPath(psiElement, "$.**.uniqueItems") ||
-                hasPath(psiElement, "$.**.readOnly") ||
-                hasPath(psiElement, "$.**.attribute") ||
-                hasPath(psiElement, "$.**.wrapped");
     }
 
     public final boolean isTagsValue(final PsiElement psiElement) {

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathDefinitionsNotInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathDefinitionsNotInRootPathResolver.java
@@ -12,11 +12,6 @@ public class PathDefinitionsNotInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*.*.*") && !childOfParameters(psiElement);
     }
 
-    public final boolean childOfExternalDocs(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.*.*.*.externalDocs") ||
-                hasPath(psiElement, "$.**.schema.externalDocs");
-    }
-
     public final boolean childOfParameters(final PsiElement psiElement) {
         return hasPath(psiElement, "$.*.*.*.parameters");
     }
@@ -51,14 +46,6 @@ public class PathDefinitionsNotInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.**.schema.items");
     }
 
-    public final boolean childOfPropertiesSchema(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.properties.*");
-    }
-
-    public final boolean childOfAdditionalProperties(PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.additionalProperties");
-    }
-
     public final boolean childOfXml(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.schema.xml");
     }
@@ -67,30 +54,6 @@ public class PathDefinitionsNotInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*.*.*.consumes") ||
                 hasPath(psiElement, "$.*.*.*.produces");
 
-    }
-
-    public final boolean isFormatValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.format");
-    }
-
-    public final boolean isTypeValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.type");
-    }
-
-    public final boolean isInValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.in");
-    }
-
-    public final boolean isBooleanValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.deprecated") ||
-                hasPath(psiElement, "$.**.required") ||
-                hasPath(psiElement, "$.**.allowEmptyValue") ||
-                hasPath(psiElement, "$.**.exclusiveMaximum") ||
-                hasPath(psiElement, "$.**.exclusiveMinimum") ||
-                hasPath(psiElement, "$.**.uniqueItems") ||
-                hasPath(psiElement, "$.**.readOnly") ||
-                hasPath(psiElement, "$.**.attribute") ||
-                hasPath(psiElement, "$.**.wrapped");
     }
 
     public final boolean isTagsValue(final PsiElement psiElement) {

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathPathResolver.java
@@ -12,11 +12,6 @@ public class PathPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*") && !childOfParameters(psiElement);
     }
 
-    public final boolean childOfExternalDocs(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.*.externalDocs") ||
-                hasPath(psiElement, "$.**.schema.externalDocs");
-    }
-
     public final boolean childOfParameters(final PsiElement psiElement) {
         return hasPath(psiElement, "$.*.parameters");
     }
@@ -51,14 +46,6 @@ public class PathPathResolver implements PathResolver {
         return hasPath(psiElement, "$.**.schema.items");
     }
 
-    public final boolean childOfPropertiesSchema(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.properties.*");
-    }
-
-    public final boolean childOfAdditionalProperties(PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.additionalProperties");
-    }
-
     public final boolean childOfXml(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.schema.xml");
     }
@@ -67,30 +54,6 @@ public class PathPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*.consumes") ||
                 hasPath(psiElement, "$.*.produces");
 
-    }
-
-    public final boolean isFormatValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.format");
-    }
-
-    public final boolean isTypeValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.type");
-    }
-
-    public final boolean isInValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.in");
-    }
-
-    public final boolean isBooleanValue(final PsiElement psiElement) {
-        return hasPath(psiElement, "$.**.deprecated") ||
-                hasPath(psiElement, "$.**.required") ||
-                hasPath(psiElement, "$.**.allowEmptyValue") ||
-                hasPath(psiElement, "$.**.exclusiveMaximum") ||
-                hasPath(psiElement, "$.**.exclusiveMinimum") ||
-                hasPath(psiElement, "$.**.uniqueItems") ||
-                hasPath(psiElement, "$.**.readOnly") ||
-                hasPath(psiElement, "$.**.attribute") ||
-                hasPath(psiElement, "$.**.wrapped");
     }
 
     public final boolean isTagsValue(final PsiElement psiElement) {

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathResolver.java
@@ -29,9 +29,10 @@ public interface PathResolver {
         return false;
     }
 
-    default boolean childOfExternalDocs(PsiElement psiElement) {
-        return false;
+    default boolean childOfExternalDocs(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.externalDocs");
     }
+
 
     default boolean childOfParameters(PsiElement psiElement) {
         return false;
@@ -78,11 +79,11 @@ public interface PathResolver {
     }
 
     default boolean childOfPropertiesSchema(PsiElement psiElement) {
-        return false;
+        return hasPath(psiElement, "$.**.properties.*");
     }
 
     default boolean childOfAdditionalProperties(PsiElement psiElement) {
-        return false;
+        return hasPath(psiElement, "$.**.additionalProperties");
     }
 
     default boolean childOfXml(PsiElement psiElement) {
@@ -149,21 +150,30 @@ public interface PathResolver {
         return false;
     }
 
-    default boolean isFormatValue(PsiElement psiElement) {
-        return false;
+    default boolean isFormatValue(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.format");
     }
 
-    default boolean isTypeValue(PsiElement psiElement) {
-        return false;
+    default boolean isTypeValue(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.type");
     }
 
-    default boolean isInValue(PsiElement psiElement) {
-        return false;
+    default boolean isInValue(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.in");
     }
 
-    default boolean isBooleanValue(PsiElement psiElement) {
-        return false;
+    default boolean isBooleanValue(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.**.deprecated") ||
+                hasPath(psiElement, "$.**.required") ||
+                hasPath(psiElement, "$.**.allowEmptyValue") ||
+                hasPath(psiElement, "$.**.exclusiveMaximum") ||
+                hasPath(psiElement, "$.**.exclusiveMinimum") ||
+                hasPath(psiElement, "$.**.uniqueItems") ||
+                hasPath(psiElement, "$.**.readOnly") ||
+                hasPath(psiElement, "$.**.attribute") ||
+                hasPath(psiElement, "$.**.wrapped");
     }
+
 
     default boolean hasPath(final PsiElement psiElement, final String pathExpression) {
         return new PathFinder().isInsidePath(psiElement, pathExpression);


### PR DESCRIPTION
Moved some of the value completions to default
implementations. We don't need to be so strict
about the locations of some keys, "format" as an example.

Fixes #160