### PR TITLE
Added warnings for unused references

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/annotator/swagger/JsonUnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/swagger/JsonUnusedRefAnnotator.java
@@ -1,0 +1,21 @@
+package org.zalando.intellij.swagger.annotator.swagger;
+
+import com.intellij.psi.PsiElement;
+import org.zalando.intellij.swagger.traversal.JsonTraversal;
+
+public class JsonUnusedRefAnnotator extends UnusedRefAnnotator {
+
+    public JsonUnusedRefAnnotator() {
+        super(new JsonTraversal());
+    }
+
+    @Override
+    public PsiElement getPsiElement(final PsiElement psiElement) {
+        return psiElement.getParent().getParent().getParent();
+    }
+
+    @Override
+    public PsiElement getSearchablePsiElement(final PsiElement psiElement) {
+        return psiElement.getParent().getParent();
+    }
+}

--- a/src/main/java/org/zalando/intellij/swagger/annotator/swagger/UnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/swagger/UnusedRefAnnotator.java
@@ -1,0 +1,79 @@
+package org.zalando.intellij.swagger.annotator.swagger;
+
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.search.searches.ReferencesSearch;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.file.SwaggerFileType;
+import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
+import org.zalando.intellij.swagger.traversal.Traversal;
+import org.zalando.intellij.swagger.traversal.path.swagger.PathResolver;
+import org.zalando.intellij.swagger.traversal.path.swagger.PathResolverFactory;
+
+public abstract class UnusedRefAnnotator implements Annotator {
+
+    private final Traversal traversal;
+    private final SwaggerIndexService swaggerIndexService = new SwaggerIndexService();
+
+    UnusedRefAnnotator(Traversal traversal) {
+        this.traversal = traversal;
+    }
+
+    public abstract PsiElement getPsiElement(PsiElement psiElement);
+
+    public abstract PsiElement getSearchablePsiElement(PsiElement psiElement);
+
+    @Override
+    public void annotate(@NotNull final PsiElement psiElement, @NotNull final AnnotationHolder annotationHolder) {
+        final Project project = psiElement.getProject();
+        final VirtualFile virtualFile = psiElement.getContainingFile().getVirtualFile();
+
+        final boolean isMainSwaggerFile = swaggerIndexService.isMainSwaggerFile(
+                virtualFile,
+                project);
+
+        final boolean isPartialSwaggerFile = swaggerIndexService.isPartialSwaggerFile(
+                virtualFile,
+                project);
+
+        if (isMainSwaggerFile || isPartialSwaggerFile) {
+            final SwaggerFileType swaggerFileType = isMainSwaggerFile
+                    ? SwaggerFileType.MAIN
+                    : swaggerIndexService.getSwaggerFileType(virtualFile,
+                    project);
+
+            final PathResolver pathResolver = PathResolverFactory.fromSwaggerFileType(swaggerFileType);
+
+            traversal.getKeyNameIfKey(psiElement).ifPresent(keyName -> {
+                final PsiElement currentElement = getPsiElement(psiElement);
+                PsiElement searchableCurrentElement = getSearchablePsiElement(psiElement);
+
+                if (pathResolver.isDefinition(currentElement)) {
+                    warn(psiElement, annotationHolder, searchableCurrentElement, "Definition is never used");
+                } else if (pathResolver.isParameter(currentElement)) {
+                    warn(psiElement, annotationHolder, searchableCurrentElement, "Parameter is never used");
+                } else if (pathResolver.isResponse(currentElement)) {
+                    warn(psiElement, annotationHolder, searchableCurrentElement, "Response is never used");
+                }
+            });
+        }
+    }
+
+    private void warn(final PsiElement psiElement,
+                      final AnnotationHolder annotationHolder,
+                      final PsiElement searchableCurrentElement,
+                      final String warning) {
+        final PsiReference first = ReferencesSearch.search(searchableCurrentElement).findFirst();
+
+        if (first == null) {
+            Annotation annotation = annotationHolder.createWeakWarningAnnotation(psiElement, warning);
+            annotation.setHighlightType(ProblemHighlightType.LIKE_UNUSED_SYMBOL);
+        }
+    }
+}

--- a/src/main/java/org/zalando/intellij/swagger/annotator/swagger/YamlUnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/swagger/YamlUnusedRefAnnotator.java
@@ -1,0 +1,22 @@
+package org.zalando.intellij.swagger.annotator.swagger;
+
+import com.intellij.psi.PsiElement;
+import org.zalando.intellij.swagger.traversal.YamlTraversal;
+
+public class YamlUnusedRefAnnotator extends UnusedRefAnnotator {
+
+    public YamlUnusedRefAnnotator() {
+        super(new YamlTraversal());
+    }
+
+    @Override
+    public PsiElement getPsiElement(final PsiElement psiElement) {
+        return psiElement.getParent().getParent();
+    }
+
+    @Override
+    public PsiElement getSearchablePsiElement(final PsiElement psiElement) {
+        return psiElement.getParent();
+    }
+
+}

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsInRootPathResolver.java
@@ -13,4 +13,9 @@ public class DefinitionsInRootPathResolver implements PathResolver {
     public final boolean childOfSchemaItems(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.items");
     }
+
+    @Override
+    public boolean isDefinition(final PsiElement psiElement) {
+        return hasPath(psiElement, "$");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsNotInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/DefinitionsNotInRootPathResolver.java
@@ -13,4 +13,9 @@ public class DefinitionsNotInRootPathResolver implements PathResolver {
     public final boolean childOfSchemaItems(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.items");
     }
+
+    @Override
+    public final boolean isDefinition(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.*");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
@@ -151,4 +151,15 @@ public class MainPathResolver implements PathResolver {
         return hasPath(psiElement, "$.paths.*.*.responses.*.headers.*.collectionFormat");
     }
 
+    public boolean isDefinition(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.definitions");
+    }
+
+    public boolean isParameter(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.parameters");
+    }
+
+    public boolean isResponse(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.responses");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ParameterDefinitionsInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ParameterDefinitionsInRootPathResolver.java
@@ -9,4 +9,9 @@ public class ParameterDefinitionsInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*");
     }
 
+    @Override
+    public final boolean isParameter(final PsiElement psiElement) {
+        return hasPath(psiElement, "$");
+    }
+
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ParameterDefinitionsNotInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ParameterDefinitionsNotInRootPathResolver.java
@@ -9,4 +9,8 @@ public class ParameterDefinitionsNotInRootPathResolver implements PathResolver {
         return hasPath(psiElement, "$.*.*");
     }
 
+    @Override
+    public final boolean isParameter(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.*");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/PathResolver.java
@@ -178,4 +178,16 @@ public interface PathResolver {
     default boolean hasPath(final PsiElement psiElement, final String pathExpression) {
         return new PathFinder().isInsidePath(psiElement, pathExpression);
     }
+
+    default boolean isDefinition(final PsiElement psiElement) {
+        return false;
+    }
+
+    default boolean isParameter(final PsiElement psiElement) {
+        return false;
+    }
+
+    default boolean isResponse(final PsiElement psiElement) {
+        return false;
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ResponseDefinitionsInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ResponseDefinitionsInRootPathResolver.java
@@ -18,4 +18,9 @@ public class ResponseDefinitionsInRootPathResolver implements PathResolver {
     public final boolean childOfSchemaItems(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.schema.items");
     }
+
+    @Override
+    public final boolean isResponse(final PsiElement psiElement) {
+        return hasPath(psiElement, "$");
+    }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ResponseDefinitionsNotInRootPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/ResponseDefinitionsNotInRootPathResolver.java
@@ -18,4 +18,9 @@ public class ResponseDefinitionsNotInRootPathResolver implements PathResolver {
     public final boolean childOfSchemaItems(final PsiElement psiElement) {
         return hasPath(psiElement, "$.**.schema.items");
     }
+
+    @Override
+    public final boolean isResponse(final PsiElement psiElement) {
+        return hasPath(psiElement, "$.*");
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -34,6 +34,9 @@
         <annotator language="JSON" implementationClass="org.zalando.intellij.swagger.annotator.JsonValidValueAnnotator"/>
         <annotator language="yaml" implementationClass="org.zalando.intellij.swagger.annotator.YamlValidValueAnnotator"/>
 
+        <annotator language="JSON" implementationClass="org.zalando.intellij.swagger.annotator.swagger.JsonUnusedRefAnnotator"/>
+        <annotator language="yaml" implementationClass="org.zalando.intellij.swagger.annotator.swagger.YamlUnusedRefAnnotator"/>
+
         <webBrowserUrlProvider implementation="org.zalando.intellij.swagger.ui.provider.SwaggerUiUrlProvider" order="last"/>
 
         <fileBasedIndex implementation="org.zalando.intellij.swagger.index.swagger.SwaggerFileIndex" />

--- a/src/test/java/org/zalando/intellij/swagger/validator/json/UnusedRefTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/json/UnusedRefTest.java
@@ -1,0 +1,66 @@
+package org.zalando.intellij.swagger.validator.json;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
+
+public class UnusedRefTest extends SwaggerLightCodeInsightFixtureTestCase {
+
+    private void doTest(final String fileName) {
+        myFixture.testHighlighting(true, false, true, "validator/field/" + fileName);
+    }
+
+    public void testUnusedDefinitionMainFile() {
+        doTest("unused_definition_main_file.json");
+    }
+
+    public void testUnusedParameterMainFile() {
+        doTest("unused_parameter_main_file.json");
+    }
+
+    public void testUnusedResponseMainFile() {
+        doTest("unused_response_main_file.json");
+    }
+
+    public void testUnusedDefinitionWhereDefinitionsAreInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_definition_in_root.json", "definitions.json");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_definition_in_root_swagger.json", "swagger.json");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, false, true, virtualFile);
+    }
+
+    public void testUnusedParameterWhereParametersAreInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_parameter_in_root.json", "parameters.json");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_parameter_in_root_swagger.json", "swagger.json");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, false, true, virtualFile);
+    }
+
+    public void testUnusedResponseWhereResponsesAreInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_response_in_root.json", "responses.json");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_response_in_root_swagger.json", "swagger.json");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, false, true, virtualFile);
+    }
+
+    public void testUnusedDefinitionWhereDefinitionsAreNotInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_definition_not_in_root.json", "definitions.json");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_definition_not_in_root_swagger.json", "swagger.json");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, false, true, virtualFile);
+    }
+
+    public void testUnusedParameterWhereParametersAreNotInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_parameter_not_in_root.json", "parameters.json");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_parameter_not_in_root_swagger.json", "swagger.json");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, false, true, virtualFile);
+    }
+
+    public void testUnusedResponseWhereResponsesAreNotInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_response_not_in_root.json", "responses.json");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_response_not_in_root_swagger.json", "swagger.json");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, false, true, virtualFile);
+    }
+
+}

--- a/src/test/java/org/zalando/intellij/swagger/validator/yaml/UnusedRefTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/yaml/UnusedRefTest.java
@@ -1,0 +1,65 @@
+package org.zalando.intellij.swagger.validator.yaml;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
+
+public class UnusedRefTest extends SwaggerLightCodeInsightFixtureTestCase {
+
+    private void doTest(final String fileName) {
+        myFixture.testHighlighting(true, true, true, "validator/field/" + fileName);
+    }
+
+    public void testUnusedDefinitionMainFile() {
+        doTest("unused_definition_main_file.yaml");
+    }
+
+    public void testUnusedParameterMainFile() {
+        doTest("unused_parameter_main_file.yaml");
+    }
+
+    public void testUnusedResponseMainFile() {
+        doTest("unused_response_main_file.yaml");
+    }
+
+    public void testUnusedDefinitionWhereDefinitionsAreInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_definition_in_root.yaml", "definitions.yaml");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_definition_in_root_swagger.yaml", "swagger.yaml");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, true, true, virtualFile);
+    }
+
+    public void testUnusedParameterWhereParametersAreInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_parameter_in_root.yaml", "parameters.yaml");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_parameter_in_root_swagger.yaml", "swagger.yaml");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, true, true, virtualFile);
+    }
+
+    public void testUnusedResponseWhereResponsesAreInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_response_in_root.yaml", "responses.yaml");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_response_in_root_swagger.yaml", "swagger.yaml");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, true, true, virtualFile);
+    }
+
+    public void testUnusedDefinitionWhereDefinitionsAreNotInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_definition_not_in_root.yaml", "definitions.yaml");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_definition_not_in_root_swagger.yaml", "swagger.yaml");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, true, true, virtualFile);
+    }
+
+    public void testUnusedParameterWhereParametersAreNotInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_parameter_not_in_root.yaml", "parameters.yaml");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_parameter_not_in_root_swagger.yaml", "swagger.yaml");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, true, true, virtualFile);
+    }
+
+    public void testUnusedResponseWhereResponsesAreNotInRoot() {
+        final VirtualFile virtualFile = myFixture.copyFileToProject("validator/field/unused_response_not_in_root.yaml", "responses.yaml");
+        final VirtualFile swaggerFile = myFixture.copyFileToProject("validator/field/unused_response_not_in_root_swagger.yaml", "swagger.yaml");
+        myFixture.configureFromExistingVirtualFile(swaggerFile);
+        myFixture.testHighlighting(true, true, true, virtualFile);
+    }
+}

--- a/src/test/resources/testing/validator/field/unused_definition_in_root.json
+++ b/src/test/resources/testing/validator/field/unused_definition_in_root.json
@@ -1,0 +1,4 @@
+{
+ "Pets": {},
+  <weak_warning descr="Definition is never used">"Cats"</weak_warning>: {}
+}

--- a/src/test/resources/testing/validator/field/unused_definition_in_root.yaml
+++ b/src/test/resources/testing/validator/field/unused_definition_in_root.yaml
@@ -1,0 +1,2 @@
+Pets:
+<weak_warning descr="Definition is never used">Cats:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_definition_in_root_swagger.json
+++ b/src/test/resources/testing/validator/field/unused_definition_in_root_swagger.json
@@ -1,0 +1,16 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "definitions.json#/Pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_definition_in_root_swagger.yaml
+++ b/src/test/resources/testing/validator/field/unused_definition_in_root_swagger.yaml
@@ -1,0 +1,8 @@
+swagger: '2.0'
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          schema:
+            "$ref": 'definitions.yaml#/Pets'

--- a/src/test/resources/testing/validator/field/unused_definition_main_file.json
+++ b/src/test/resources/testing/validator/field/unused_definition_main_file.json
@@ -1,0 +1,9 @@
+{
+  "swagger": "2.0",
+  "definitions": {
+    <weak_warning descr="Definition is never used">"def1"</weak_warning>: {
+      "$ref": "#/definitions/def2"
+    },
+    "def2": {}
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_definition_main_file.yaml
+++ b/src/test/resources/testing/validator/field/unused_definition_main_file.yaml
@@ -1,0 +1,5 @@
+swagger: "2.0"
+definitions:
+  <weak_warning descr="Definition is never used">def1:</weak_warning>
+    $ref: '#/definitions/def2'
+  def2:

--- a/src/test/resources/testing/validator/field/unused_definition_not_in_root.json
+++ b/src/test/resources/testing/validator/field/unused_definition_not_in_root.json
@@ -1,0 +1,6 @@
+{
+  "models": {
+    "Pets": {},
+    <weak_warning descr="Definition is never used">"Cats"</weak_warning>: {}
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_definition_not_in_root.yaml
+++ b/src/test/resources/testing/validator/field/unused_definition_not_in_root.yaml
@@ -1,0 +1,3 @@
+models:
+  Pets:
+  <weak_warning descr="Definition is never used">Cats:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_definition_not_in_root_swagger.json
+++ b/src/test/resources/testing/validator/field/unused_definition_not_in_root_swagger.json
@@ -1,0 +1,16 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "definitions.json#/models/Pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_definition_not_in_root_swagger.yaml
+++ b/src/test/resources/testing/validator/field/unused_definition_not_in_root_swagger.yaml
@@ -1,0 +1,8 @@
+swagger: '2.0'
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          schema:
+            "$ref": 'definitions.yaml#/models/Pets'

--- a/src/test/resources/testing/validator/field/unused_parameter_in_root.json
+++ b/src/test/resources/testing/validator/field/unused_parameter_in_root.json
@@ -1,0 +1,4 @@
+{
+  "Pets": {},
+  <weak_warning descr="Parameter is never used">"Cats"</weak_warning>: {}
+}

--- a/src/test/resources/testing/validator/field/unused_parameter_in_root.yaml
+++ b/src/test/resources/testing/validator/field/unused_parameter_in_root.yaml
@@ -1,0 +1,2 @@
+Pets:
+<weak_warning descr="Parameter is never used">Cats:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_parameter_in_root_swagger.json
+++ b/src/test/resources/testing/validator/field/unused_parameter_in_root_swagger.json
@@ -1,0 +1,14 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "parameters.json#/Pets"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_parameter_in_root_swagger.yaml
+++ b/src/test/resources/testing/validator/field/unused_parameter_in_root_swagger.yaml
@@ -1,0 +1,6 @@
+swagger: '2.0'
+paths:
+  /pets:
+    get:
+      parameters:
+        - $ref: 'parameters.yaml#/Pets'

--- a/src/test/resources/testing/validator/field/unused_parameter_main_file.json
+++ b/src/test/resources/testing/validator/field/unused_parameter_main_file.json
@@ -1,0 +1,18 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/Dog"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "Dog": null,
+    <weak_warning descr="Parameter is never used">"Cats"</weak_warning>: {}
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_parameter_main_file.yaml
+++ b/src/test/resources/testing/validator/field/unused_parameter_main_file.yaml
@@ -1,0 +1,9 @@
+swagger: '2.0'
+paths:
+  /pets:
+    get:
+      parameters:
+        - $ref: '#/parameters/Dog'
+parameters:
+  Dog:
+  <weak_warning descr="Parameter is never used">Cat:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_parameter_not_in_root.json
+++ b/src/test/resources/testing/validator/field/unused_parameter_not_in_root.json
@@ -1,0 +1,6 @@
+{
+  "parameters": {
+    "Pets": {},
+    <weak_warning descr="Parameter is never used">"Cats"</weak_warning>: {}
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_parameter_not_in_root.yaml
+++ b/src/test/resources/testing/validator/field/unused_parameter_not_in_root.yaml
@@ -1,0 +1,3 @@
+parameters:
+  Pets:
+  <weak_warning descr="Parameter is never used">Cats:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_parameter_not_in_root_swagger.json
+++ b/src/test/resources/testing/validator/field/unused_parameter_not_in_root_swagger.json
@@ -1,0 +1,14 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "parameters.json#/parameters/Pets"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_parameter_not_in_root_swagger.yaml
+++ b/src/test/resources/testing/validator/field/unused_parameter_not_in_root_swagger.yaml
@@ -1,0 +1,6 @@
+swagger: '2.0'
+paths:
+  /pets:
+    get:
+      parameters:
+        - $ref: 'parameters.yaml#/parameters/Pets'

--- a/src/test/resources/testing/validator/field/unused_response_in_root.json
+++ b/src/test/resources/testing/validator/field/unused_response_in_root.json
@@ -1,0 +1,4 @@
+{
+  "Pets": {},
+  <weak_warning descr="Response is never used">"Cats"</weak_warning>: {}
+}

--- a/src/test/resources/testing/validator/field/unused_response_in_root.yaml
+++ b/src/test/resources/testing/validator/field/unused_response_in_root.yaml
@@ -1,0 +1,2 @@
+Pets:
+<weak_warning descr="Response is never used">Cats:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_response_in_root_swagger.json
+++ b/src/test/resources/testing/validator/field/unused_response_in_root_swagger.json
@@ -1,0 +1,14 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/path": {
+      "get": {
+        "responses": {
+          "200": {
+            "$ref": "responses.json#/Pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_response_in_root_swagger.yaml
+++ b/src/test/resources/testing/validator/field/unused_response_in_root_swagger.yaml
@@ -1,0 +1,7 @@
+swagger: '2.0'
+paths:
+  /path:
+    get:
+      responses:
+        200:
+          $ref: 'responses.yaml#/Pets'

--- a/src/test/resources/testing/validator/field/unused_response_main_file.json
+++ b/src/test/resources/testing/validator/field/unused_response_main_file.json
@@ -1,0 +1,18 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/path": {
+      "get": {
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Dog"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "Dog": null,
+    <weak_warning descr="Response is never used">"Cats"</weak_warning>: {}
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_response_main_file.yaml
+++ b/src/test/resources/testing/validator/field/unused_response_main_file.yaml
@@ -1,0 +1,10 @@
+swagger: '2.0'
+paths:
+  /path:
+    get:
+      responses:
+        200:
+          $ref: '#/responses/Dog'
+responses:
+  Dog:
+  <weak_warning descr="Response is never used">Cat:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_response_not_in_root.json
+++ b/src/test/resources/testing/validator/field/unused_response_not_in_root.json
@@ -1,0 +1,6 @@
+{
+  "responses": {
+    "Pets": {},
+    <weak_warning descr="Response is never used">"Cats"</weak_warning>: {}
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_response_not_in_root.yaml
+++ b/src/test/resources/testing/validator/field/unused_response_not_in_root.yaml
@@ -1,0 +1,3 @@
+responses:
+  Pets:
+  <weak_warning descr="Response is never used">Cats:</weak_warning>

--- a/src/test/resources/testing/validator/field/unused_response_not_in_root_swagger.json
+++ b/src/test/resources/testing/validator/field/unused_response_not_in_root_swagger.json
@@ -1,0 +1,14 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/path": {
+      "get": {
+        "responses": {
+          "200": {
+            "$ref": "responses.json#/responses/Pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/unused_response_not_in_root_swagger.yaml
+++ b/src/test/resources/testing/validator/field/unused_response_not_in_root_swagger.yaml
@@ -1,0 +1,7 @@
+swagger: '2.0'
+paths:
+  /path:
+    get:
+      responses:
+        200:
+          $ref: 'responses.yaml#/responses/Pets'


### PR DESCRIPTION
This commit adds warnings to definitions, parameters and
responses that are never used.

Fixes #78