### PR TITLE
Improve UX for editing the spec

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
@@ -47,7 +47,7 @@ public class SwaggerUiUrlProvider extends BuiltInWebBrowserUrlProvider implement
                         final boolean swaggerFile = fileDetector.isMainSwaggerFile(psiFile) || fileDetector.isMainOpenApiFile(psiFile);
 
                         if (swaggerFile) {
-                            swaggerFileService.convertSwaggerToHtml(psiFile);
+                            swaggerFileService.convertSwaggerToHtmlAsync(psiFile);
                         }
                     }
                 }


### PR DESCRIPTION
Previously when a spec file was saved, Swagger UI files were
updated in the same UI thread, making the UI unresponsive.

This commit introduces async updates, so that on each file save,
the Swagger UI files are processed in a separate thread.