### PR TITLE
Switched to document listener extension point

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
@@ -1,0 +1,36 @@
+package org.zalando.intellij.swagger.ui.provider;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.file.FileDetector;
+import org.zalando.intellij.swagger.service.SwaggerFileService;
+
+public class FileDocumentListener extends FileDocumentManagerAdapter {
+
+    private final FileDetector fileDetector = new FileDetector();
+
+    @Override
+    public void beforeDocumentSaving(@NotNull final Document document) {
+        SwaggerFileService swaggerFileService = ServiceManager.getService(SwaggerFileService.class);
+        final Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
+
+        if (openProjects.length > 0) {
+            final PsiFile psiFile = PsiDocumentManager.getInstance(openProjects[0]).getPsiFile(document);
+
+            if (psiFile != null) {
+                final boolean swaggerFile = fileDetector.isMainSwaggerFile(psiFile) || fileDetector.isMainOpenApiFile(psiFile);
+
+                if (swaggerFile) {
+                    swaggerFileService.convertSwaggerToHtmlAsync(psiFile);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
@@ -1,16 +1,9 @@
 package org.zalando.intellij.swagger.ui.provider;
 
-import com.intellij.AppTopics;
 import com.intellij.ide.browsers.OpenInBrowserRequest;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
-import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
 import com.intellij.openapi.project.DumbAware;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.Url;
 import org.jetbrains.annotations.NotNull;
@@ -25,35 +18,7 @@ import java.util.Optional;
 
 public class SwaggerUiUrlProvider extends BuiltInWebBrowserUrlProvider implements DumbAware {
 
-    private final FileDetector fileDetector;
-
-    public SwaggerUiUrlProvider() {
-        this(new FileDetector());
-    }
-
-    private SwaggerUiUrlProvider(final FileDetector fileDetector) {
-        this.fileDetector = fileDetector;
-
-        ApplicationManager.getApplication().getMessageBus().connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, new FileDocumentManagerAdapter() {
-            @Override
-            public void beforeDocumentSaving(@NotNull final Document document) {
-                SwaggerFileService swaggerFileService = ServiceManager.getService(SwaggerFileService.class);
-                final Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
-
-                if (openProjects.length > 0) {
-                    final PsiFile psiFile = PsiDocumentManager.getInstance(openProjects[0]).getPsiFile(document);
-
-                    if (psiFile != null) {
-                        final boolean swaggerFile = fileDetector.isMainSwaggerFile(psiFile) || fileDetector.isMainOpenApiFile(psiFile);
-
-                        if (swaggerFile) {
-                            swaggerFileService.convertSwaggerToHtmlAsync(psiFile);
-                        }
-                    }
-                }
-            }
-            });
-    }
+    private final FileDetector fileDetector = new FileDetector();
 
     @Override
     public boolean canHandleElement(@NotNull OpenInBrowserRequest request) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,7 +20,7 @@
         <extensionPoint qualifiedName="org.zalando.intellij.swagger.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory"/>
         <extensionPoint qualifiedName="org.zalando.intellij.swagger.customValueFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomValueCompletionFactory"/>
     </extensionPoints>
-    
+
     <extensions defaultExtensionNs="com.intellij">
         <completion.contributor language="JSON" implementationClass="org.zalando.intellij.swagger.completion.contributor.swagger.SwaggerJsonCompletionContributor"/>
         <completion.contributor language="yaml" implementationClass="org.zalando.intellij.swagger.completion.contributor.swagger.SwaggerYamlCompletionContributor"/>
@@ -42,6 +42,7 @@
         <annotator language="JSON" implementationClass="org.zalando.intellij.swagger.annotator.swagger.JsonUnusedRefAnnotator"/>
         <annotator language="yaml" implementationClass="org.zalando.intellij.swagger.annotator.swagger.YamlUnusedRefAnnotator"/>
 
+        <fileDocumentManagerListener implementation="org.zalando.intellij.swagger.ui.provider.FileDocumentListener"/>
         <webBrowserUrlProvider implementation="org.zalando.intellij.swagger.ui.provider.SwaggerUiUrlProvider" order="last"/>
 
         <fileBasedIndex implementation="org.zalando.intellij.swagger.index.swagger.SwaggerFileIndex" />


### PR DESCRIPTION
It is better to use an extension point rather than listening
events from the event bus. It is safer (see https://youtrack.jetbrains.com/issue/IDEA-71701)
and improved readability.