### PR TITLE
Fixed key completion with arrays / duplicate keys

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/completion/CompletionHelper.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/CompletionHelper.java
@@ -28,7 +28,7 @@ public class CompletionHelper {
     }
     
     public boolean isUniqueKey(final String keyName) {
-        List<? extends PsiNamedElement> children = new PathFinder().findChildrenByPathFrom("parent", psiElement);
+        List<? extends PsiNamedElement> children = new PathFinder().findDirectNamedChildren("parent", psiElement);
 
         return children.stream()
                 .noneMatch((c) -> keyName.equals(c.getName()));

--- a/src/main/java/org/zalando/intellij/swagger/completion/field/completion/swagger/OperationSecurityCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/field/completion/swagger/OperationSecurityCompletion.java
@@ -42,7 +42,7 @@ class OperationSecurityCompletion extends FieldCompletion {
     private List<ArrayField> getSecurityDefinitions() {
         final PsiFile containingFile = completionHelper.getPsiFile().getContainingFile();
         final List<? extends PsiNamedElement> securityDefinitions =
-                new PathFinder().findChildrenByPathFrom("$.securityDefinitions", containingFile);
+                new PathFinder().findNamedChildren("$.securityDefinitions", containingFile);
 
         return securityDefinitions.stream()
                 .map(PsiNamedElement::getName)

--- a/src/main/java/org/zalando/intellij/swagger/completion/field/completion/swagger/RootSecurityCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/field/completion/swagger/RootSecurityCompletion.java
@@ -22,7 +22,7 @@ class RootSecurityCompletion extends FieldCompletion {
         getSecurityDefinitions().forEach(field -> {
             final PsiFile containingFile = completionHelper.getPsiFile().getContainingFile();
             final List<? extends PsiNamedElement> security =
-                    new PathFinder().findChildrenByPathFrom("$.security", containingFile);
+                    new PathFinder().findNamedChildren("$.security", containingFile);
             final List<String> existingNames = extractNames(security);
 
             if (!existingNames.contains(field.getName())) {
@@ -40,7 +40,7 @@ class RootSecurityCompletion extends FieldCompletion {
     private List<ArrayField> getSecurityDefinitions() {
         final PsiFile containingFile = completionHelper.getPsiFile().getContainingFile();
         final List<? extends PsiNamedElement> securityDefinitions =
-                new PathFinder().findChildrenByPathFrom("$.securityDefinitions", containingFile);
+                new PathFinder().findNamedChildren("$.securityDefinitions", containingFile);
 
         return securityDefinitions.stream()
                 .map(PsiNamedElement::getName)

--- a/src/main/java/org/zalando/intellij/swagger/completion/value/completion/openapi/ComponentRefValueCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/value/completion/openapi/ComponentRefValueCompletion.java
@@ -31,7 +31,7 @@ class ComponentRefValueCompletion extends ValueCompletion {
         final PsiFile psiFile = completionHelper.getPsiFile();
         final String pathExpression = String.format("$.components.%s", refType);
 
-        return new PathFinder().findChildrenByPathFrom(pathExpression, psiFile).stream()
+        return new PathFinder().findNamedChildren(pathExpression, psiFile).stream()
                 .map(e -> String.format("#/components/%s/%s", refType, e.getName()))
                 .map(StringValue::new)
                 .collect(Collectors.toList());

--- a/src/main/java/org/zalando/intellij/swagger/completion/value/completion/swagger/LocalRefValueCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/value/completion/swagger/LocalRefValueCompletion.java
@@ -31,7 +31,7 @@ class LocalRefValueCompletion extends ValueCompletion {
         final PsiFile psiFile = completionHelper.getPsiFile();
         final String pathExpression = String.format("$.%s", refType);
 
-        return new PathFinder().findChildrenByPathFrom(pathExpression, psiFile).stream()
+        return new PathFinder().findNamedChildren(pathExpression, psiFile).stream()
                 .map(e -> String.format("#/%s/%s", refType, e.getName()))
                 .map(StringValue::new)
                 .collect(Collectors.toList());

--- a/src/main/java/org/zalando/intellij/swagger/completion/value/completion/swagger/SecurityScopeNameValueCompletion.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/value/completion/swagger/SecurityScopeNameValueCompletion.java
@@ -30,7 +30,7 @@ class SecurityScopeNameValueCompletion extends ValueCompletion {
     private List<Value> getSecurityDefinitionByName(final String securityDefinitionName) {
         final PsiFile containingFile = completionHelper.getPsiFile().getContainingFile();
         final List<? extends PsiNamedElement> securityDefinitions =
-                new PathFinder().findChildrenByPathFrom("$.securityDefinitions", containingFile);
+                new PathFinder().findNamedChildren("$.securityDefinitions", containingFile);
 
         return securityDefinitions.stream()
                 .filter(e -> securityDefinitionName.equals(completionHelper.getKeyNameOfObject(e).orElse(null)))

--- a/src/main/java/org/zalando/intellij/swagger/validator/value/ReferenceValidator.java
+++ b/src/main/java/org/zalando/intellij/swagger/validator/value/ReferenceValidator.java
@@ -83,7 +83,7 @@ public class ReferenceValidator {
     private Set<String> getAvailableNames(final PsiElement psiElement, final String refType) {
         String pathExpression = String.format("$.%s", refType);
 
-        return new PathFinder().findChildrenByPathFrom(pathExpression, psiElement.getContainingFile())
+        return new PathFinder().findNamedChildren(pathExpression, psiElement.getContainingFile())
                 .stream()
                 .map(PsiNamedElement::getName)
                 .collect(Collectors.toSet());

--- a/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
@@ -120,6 +120,16 @@ public class SwaggerCompletionTest extends JsonAndYamlCompletionTest {
     }
 
     @Test
+    public void thatRefKeyIsSuggestedEvenIfParametersHaveExistingRef() {
+        getCaretCompletions("parameters_ref")
+                .assertContains("$ref", "name", "in", "description", "required", "schema", "type", "format",
+                        "allowEmptyValue", "items", "collectionFormat", "default", "maximum", "exclusiveMaximum",
+                        "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems",
+                        "uniqueItems", "enum", "multipleOf")
+                .isOfSize(24);
+    }
+
+    @Test
     public void thatItemsKeysInOperationParametersAreSuggested() {
         getCaretCompletions("items_in_operation_parameters")
                 .assertContains("type", "format", "items", "collectionFormat", "default", "maximum",

--- a/src/test/resources/testing/completion/field/swagger/parameters_ref.json
+++ b/src/test/resources/testing/completion/field/swagger/parameters_ref.json
@@ -1,0 +1,17 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pathA": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "ref1"
+          },
+          {
+            <caret>
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/completion/field/swagger/parameters_ref.yaml
+++ b/src/test/resources/testing/completion/field/swagger/parameters_ref.yaml
@@ -1,0 +1,7 @@
+swagger: '2.0'
+paths:
+  /pathA:
+    get:
+      parameters:
+        - $ref: 'ref1'
+        - <caret>


### PR DESCRIPTION
Fixed an issue where, for example, `$ref` key was not suggested
because it was already present in the parameters object:

```
parameters:
  - $ref: ref1
  - <caret> (no `$ref` suggestion available)
```

This was caused by an invalid check for a unique key.

Fixes #186