### PR TITLE
Added Zally validation to extension

### DIFF
--- a/examples/extensions-zalando/build.gradle
+++ b/examples/extensions-zalando/build.gradle
@@ -17,7 +17,7 @@ task wrapper(type: Wrapper) {
 }
 
 intellij {
-    plugins 'org.zalando.intellij.swagger:1.0.14'
+    plugins 'org.zalando.intellij.swagger:1.0.16', 'yaml'
     pluginName 'intellij-swagger-extensions-zalando'
     updateSinceUntilBuild false
     version '2016.2'
@@ -31,4 +31,9 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
+}
+
+dependencies {
+    compile 'io.github.openfeign:feign-core:10.0.1'
+    compile 'io.github.openfeign:feign-gson:10.0.1'
 }

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettings.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettings.java
@@ -1,0 +1,25 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.Nullable;
+
+@State(name = "SwaggerSetting",
+        storages = @Storage("intellij-swagger.xml"))
+public class ZallySettings implements PersistentStateComponent<ZallySettings> {
+
+    public String zallyUrl;
+
+    @Nullable
+    @Override
+    public ZallySettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(ZallySettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettingsGui.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettingsGui.java
@@ -1,0 +1,84 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SearchableConfigurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class ZallySettingsGui implements SearchableConfigurable {
+
+    private JTextField zallyUrlTextField = new JTextField(50);
+
+    @NotNull
+    @Override
+    public String getId() {
+        return "Zally";
+    }
+
+    @Nullable
+    @Override
+    public Runnable enableSearch(String option) {
+        return null;
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "Zally";
+    }
+
+    @Nullable
+    @Override
+    public String getHelpTopic() {
+        return "Zally";
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        JPanel zallyUrlPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        zallyUrlPanel.add(new JLabel("Zally API URL: "));
+        zallyUrlPanel.add(zallyUrlTextField);
+        zallyUrlPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        panel.add(zallyUrlPanel);
+
+        return panel;
+    }
+
+    @Override
+    public boolean isModified() {
+        final ZallySettings settings = ServiceManager.getService(ZallySettings.class);
+
+        return (settings.zallyUrl != null &&
+                !settings.zallyUrl.equals(zallyUrlTextField.getText())) ||
+                settings.zallyUrl == null && zallyUrlTextField.getText() != null;
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        final ZallySettings settings = ServiceManager.getService(ZallySettings.class);
+
+        settings.zallyUrl = zallyUrlTextField.getText();
+    }
+
+    @Override
+    public void reset() {
+        final ZallySettings settings = ServiceManager.getService(ZallySettings.class);
+
+        zallyUrlTextField.setText(settings.zallyUrl);
+    }
+
+    @Override
+    public void disposeUIResources() {
+
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidator.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidator.java
@@ -26,15 +26,15 @@ public class YamlFileValidator extends LocalInspectionTool {
 
     @Override
     public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
-        if (shouldValidate(file)) {
-            final LintingResponse lintingResponse = validate(file);
+        if (shouldLint(file)) {
+            final LintingResponse lintingResponse = lint(file);
             return createViolations(manager, isOnTheFly, lintingResponse, file);
         }
 
         return ProblemDescriptor.EMPTY_ARRAY;
     }
 
-    private boolean shouldValidate(final PsiFile file) {
+    private boolean shouldLint(final PsiFile file) {
         return hasZallyUrl() && isSwaggerFile(file);
     }
 
@@ -48,13 +48,13 @@ public class YamlFileValidator extends LocalInspectionTool {
         return zallySettings.zallyUrl != null && !zallySettings.zallyUrl.isEmpty();
     }
 
-    private LintingResponse validate(final PsiFile file) {
+    private LintingResponse lint(final PsiFile file) {
         try {
             final ZallyService zallyService = ServiceManager.getService(ZallyService.class);
 
-            return zallyService.validate(file.getText());
+            return zallyService.lint(file.getText());
         } catch (final Exception e) {
-            LOG.error("Could not validate specification with Zally", e);
+            LOG.error("Could not lint specification with Zally", e);
 
             throw new RuntimeException(e);
         }

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidator.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidator.java
@@ -23,6 +23,15 @@ public class YamlFileValidator extends LocalInspectionTool {
 
     private final PathFinder pathFinder = new PathFinder();
     private final FileDetector fileDetector = new FileDetector();
+    private final ZallyService zallyService;
+
+    public YamlFileValidator() {
+        this(ServiceManager.getService(ZallyService.class));
+    }
+
+    public YamlFileValidator(ZallyService zallyService) {
+        this.zallyService = zallyService;
+    }
 
     @Override
     public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
@@ -50,8 +59,6 @@ public class YamlFileValidator extends LocalInspectionTool {
 
     private LintingResponse lint(final PsiFile file) {
         try {
-            final ZallyService zallyService = ServiceManager.getService(ZallyService.class);
-
             return zallyService.lint(file.getText());
         } catch (final Exception e) {
             LOG.error("Could not lint specification with Zally", e);

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidator.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidator.java
@@ -1,0 +1,89 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
+
+import com.google.common.collect.Lists;
+import com.intellij.codeInspection.*;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.yaml.psi.YAMLKeyValue;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponse;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.Violation;
+import org.zalando.intellij.swagger.file.FileDetector;
+import org.zalando.intellij.swagger.traversal.path.PathFinder;
+
+import java.util.List;
+import java.util.Optional;
+
+public class YamlFileValidator extends LocalInspectionTool {
+
+    private final static Logger LOG = Logger.getInstance(YamlFileValidator.class);
+
+    private final PathFinder pathFinder = new PathFinder();
+    private final FileDetector fileDetector = new FileDetector();
+
+    @Override
+    public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
+        if (shouldValidate(file)) {
+            final LintingResponse lintingResponse = validate(file);
+            return createViolations(manager, isOnTheFly, lintingResponse, file);
+        }
+
+        return ProblemDescriptor.EMPTY_ARRAY;
+    }
+
+    private boolean shouldValidate(final PsiFile file) {
+        return hasZallyUrl() && isSwaggerFile(file);
+    }
+
+    private boolean isSwaggerFile(PsiFile file) {
+        return fileDetector.isMainSwaggerYamlFile(file);
+    }
+
+    private boolean hasZallyUrl() {
+        final ZallySettings zallySettings = ServiceManager.getService(ZallySettings.class);
+
+        return zallySettings.zallyUrl != null && !zallySettings.zallyUrl.isEmpty();
+    }
+
+    private LintingResponse validate(final PsiFile file) {
+        try {
+            final ZallyService zallyService = ServiceManager.getService(ZallyService.class);
+
+            return zallyService.validate(file.getText());
+        } catch (final Exception e) {
+            LOG.error("Could not validate specification with Zally", e);
+
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    private ProblemDescriptor[] createViolations(final InspectionManager manager,
+                                                 final boolean isOnTheFly,
+                                                 final LintingResponse lintingResponse,
+                                                 final PsiFile file) {
+        final List<ProblemDescriptor> problems = Lists.newArrayList();
+
+        final Optional<PsiElement> root = pathFinder.findByPathFrom("$.swagger", file);
+
+        root.filter(el -> el instanceof YAMLKeyValue)
+                .map(YAMLKeyValue.class::cast)
+                .ifPresent((psiElement) -> {
+                    final PsiElement key = psiElement.getKey();
+
+                    if (key != null) {
+                        for (Violation violation : lintingResponse.getViolations()) {
+                            String descriptionTemplate = "[" + violation.getViolationType() + "] " + violation.getTitle();
+
+                            problems.add(manager.createProblemDescriptor(psiElement.getKey(), descriptionTemplate,
+                                    isOnTheFly, LocalQuickFix.EMPTY_ARRAY, ProblemHighlightType.GENERIC_ERROR));
+                        }
+                    }
+                });
+
+        return problems.toArray(ProblemDescriptor.EMPTY_ARRAY);
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyService.java
@@ -1,0 +1,7 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
+
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponse;
+
+public interface ZallyService {
+    LintingResponse validate(final String spec);
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyService.java
@@ -3,5 +3,5 @@ package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponse;
 
 public interface ZallyService {
-    LintingResponse validate(final String spec);
+    LintingResponse lint(final String spec);
 }

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
@@ -4,7 +4,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.extensions.PluginId;
 import feign.Feign;
 import feign.Logger;
 import feign.codec.Decoder;
@@ -20,13 +23,25 @@ import java.util.Map;
 
 public class HttpZallyService implements ZallyService {
 
+    private static final String PLUGIN_ID = "org.zalando.intellij.swagger.examples.extensions.zalando";
+
+    private final IdeaPluginDescriptor plugin;
+
+    public HttpZallyService() {
+        this(PluginManager.getPlugin(PluginId.findId(PLUGIN_ID)));
+    }
+
+    public HttpZallyService(IdeaPluginDescriptor plugin) {
+        this.plugin = plugin;
+    }
+
     public LintingResponse lint(final String spec) {
         return connect().lint(zallyHeaders(), new LintingRequest(spec));
     }
 
     private Map<String, Object> zallyHeaders() {
         return ImmutableMap.of(
-                "User-Agent", "intellij-swagger-plugin/0.0.1",
+                "User-Agent", "intellij-swagger-plugin/" + plugin.getVersion(),
                 "Authorization", "Bearer " + TokenService.getToken(),
                 "Content-Type", "application/json"
         );

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
@@ -1,0 +1,52 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.http;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.intellij.openapi.components.ServiceManager;
+import feign.Feign;
+import feign.Logger;
+import feign.codec.Decoder;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.ZallyService;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingRequest;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponse;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponseErrorDecoder;
+
+import java.util.Map;
+
+public class HttpZallyService implements ZallyService {
+
+    public LintingResponse validate(final String spec) {
+        return connect().validate(zallyHeaders(), new LintingRequest(spec));
+    }
+
+    private Map<String, Object> zallyHeaders() {
+        return ImmutableMap.of(
+                "User-Agent", "intellij-swagger-plugin/0.0.1",
+                "Authorization", "Bearer " + TokenService.getToken(),
+                "Content-Type", "application/json"
+        );
+    }
+
+    private static ZallyApi connect() {
+        final String zallyUrl = ServiceManager.getService(ZallySettings.class).zallyUrl;
+
+        final Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+        final Decoder decoder = new GsonDecoder(gson);
+
+        return Feign.builder()
+                .encoder(new GsonEncoder())
+                .decoder(decoder)
+                .errorDecoder(new LintingResponseErrorDecoder())
+                .logger(new Logger.ErrorLogger())
+                .logLevel(Logger.Level.BASIC)
+                .target(ZallyApi.class, zallyUrl);
+    }
+
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
@@ -20,8 +20,8 @@ import java.util.Map;
 
 public class HttpZallyService implements ZallyService {
 
-    public LintingResponse validate(final String spec) {
-        return connect().validate(zallyHeaders(), new LintingRequest(spec));
+    public LintingResponse lint(final String spec) {
+        return connect().lint(zallyHeaders(), new LintingRequest(spec));
     }
 
     private Map<String, Object> zallyHeaders() {

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/TokenService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/TokenService.java
@@ -1,0 +1,51 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.http;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class TokenService {
+
+    private static final String CACHE_KEY = "token";
+
+    private static final LoadingCache<String, String> TOKEN_CACHE = CacheBuilder.newBuilder()
+            .maximumSize(1)
+            .expireAfterWrite(30, TimeUnit.MINUTES)
+            .build(
+                    new CacheLoader<String, String>() {
+                        public String load(String key) throws Exception {
+                            return createToken();
+                        }
+                    });
+
+    public static String getToken() {
+        try {
+            return TOKEN_CACHE.get(CACHE_KEY);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String createToken() throws IOException {
+        ProcessBuilder pb =
+                new ProcessBuilder("/bin/bash", "-c", "/usr/local/bin/ztoken");
+        pb.environment().put("LANG", "en_US.UTF-8");
+
+        Process p = pb.start();
+
+        final String token = new BufferedReader(new
+                InputStreamReader(p.getInputStream())).readLine();
+
+        if (token == null) {
+            throw new RuntimeException("Could not get a token using `ztoken`. Make sure you are logged in with `zaws login`");
+        }
+
+        return token;
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/TokenService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/TokenService.java
@@ -7,6 +7,7 @@ import com.google.common.cache.LoadingCache;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -33,11 +34,15 @@ public class TokenService {
     }
 
     private static String createToken() throws IOException {
-        ProcessBuilder pb =
-                new ProcessBuilder("/bin/bash", "-c", "/usr/local/bin/ztoken");
+        final ProcessBuilder pb = new ProcessBuilder("/bin/bash", "-c", "ztoken");
+        final String path = Optional.ofNullable(pb.environment().get("PATH"))
+                .map(p -> p.concat(":/usr/local/bin"))
+                .orElse("");
+
+        pb.environment().put("PATH", path);
         pb.environment().put("LANG", "en_US.UTF-8");
 
-        Process p = pb.start();
+        final Process p = pb.start();
 
         final String token = new BufferedReader(new
                 InputStreamReader(p.getInputStream())).readLine();

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/ZallyApi.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/ZallyApi.java
@@ -1,0 +1,14 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.http;
+
+import feign.HeaderMap;
+import feign.RequestLine;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingRequest;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponse;
+
+import java.util.Map;
+
+public interface ZallyApi {
+
+    @RequestLine("POST /api-violations")
+    LintingResponse validate(@HeaderMap Map<String, Object> headerMap, LintingRequest request);
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/ZallyApi.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/ZallyApi.java
@@ -10,5 +10,5 @@ import java.util.Map;
 public interface ZallyApi {
 
     @RequestLine("POST /api-violations")
-    LintingResponse validate(@HeaderMap Map<String, Object> headerMap, LintingRequest request);
+    LintingResponse lint(@HeaderMap Map<String, Object> headerMap, LintingRequest request);
 }

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingRequest.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingRequest.java
@@ -1,0 +1,13 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class LintingRequest {
+
+    @SerializedName("api_definition_string")
+    public final String spec;
+
+    public LintingRequest(String spec) {
+        this.spec = spec;
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingResponse.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingResponse.java
@@ -1,0 +1,16 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model;
+
+import java.util.Set;
+
+public class LintingResponse {
+
+    private final Set<Violation> violations;
+
+    public LintingResponse(Set<Violation> violations) {
+        this.violations = violations;
+    }
+
+    public Set<Violation> getViolations() {
+        return violations;
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingResponseErrorDecoder.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingResponseErrorDecoder.java
@@ -1,0 +1,11 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class LintingResponseErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        return new ZallyClientError(response.reason());
+    }}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/Violation.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/Violation.java
@@ -1,0 +1,43 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model;
+
+import com.google.common.base.Objects;
+
+public class Violation {
+
+    final private String title;
+    final private String violationType;
+    final private String ruleLink;
+
+    public Violation(String title, String violationType, String ruleLink) {
+        this.title = title;
+        this.violationType = violationType;
+        this.ruleLink = ruleLink;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getViolationType() {
+        return violationType;
+    }
+
+    public String getRuleLink() {
+        return ruleLink;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Violation violation = (Violation) o;
+        return Objects.equal(title, violation.title) &&
+                Objects.equal(violationType, violation.violationType) &&
+                Objects.equal(ruleLink, violation.ruleLink);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(title, violationType, ruleLink);
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/ZallyClientError.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/ZallyClientError.java
@@ -1,0 +1,15 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model;
+
+public class ZallyClientError extends RuntimeException {
+
+    private final String message;
+
+    public ZallyClientError(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/value/completion/swagger/SwaggerValueFactory.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/value/completion/swagger/SwaggerValueFactory.java
@@ -2,10 +2,7 @@ package org.zalando.intellij.swagger.examples.extensions.zalando.value.completio
 
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import org.zalando.intellij.swagger.completion.SwaggerCompletionHelper;
-import org.zalando.intellij.swagger.completion.field.FieldCompletion;
 import org.zalando.intellij.swagger.completion.value.ValueCompletion;
-import org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.swagger.InfoCompletion;
-import org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory;
 import org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomValueCompletionFactory;
 
 import java.util.Optional;

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/value/completion/swagger/SwaggerValues.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/value/completion/swagger/SwaggerValues.java
@@ -1,8 +1,6 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.value.completion.swagger;
 
 import com.google.common.collect.ImmutableList;
-import org.zalando.intellij.swagger.completion.field.model.common.Field;
-import org.zalando.intellij.swagger.completion.field.model.common.StringField;
 import org.zalando.intellij.swagger.completion.value.model.common.StringValue;
 import org.zalando.intellij.swagger.completion.value.model.common.Value;
 

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -16,4 +16,20 @@
         <customFieldFactory implementation="org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.swagger.SwaggerFieldFactory" />
         <customValueFactory implementation="org.zalando.intellij.swagger.examples.extensions.zalando.value.completion.swagger.SwaggerValueFactory" />
     </extensions>
+
+    <extensions defaultExtensionNs="com.intellij">
+
+        <localInspection displayName="Zally Validator" groupName="OpenAPI Validation"  enabledByDefault="true" language="yaml"
+                         implementationClass="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.YamlFileValidator"/>
+
+        <applicationService serviceInterface="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.ZallyService"
+                            serviceImplementation="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.http.HttpZallyService"
+                            testServiceImplementation="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.MockZallyService" />
+
+        <projectConfigurable groupId="tools"
+                             displayName="Zally"
+                             id="preferences.zally"
+                             instance="org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettingsGui" />
+        <applicationService serviceImplementation="org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings"/>
+    </extensions>
 </idea-plugin>

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -1,13 +1,14 @@
 <idea-plugin version="2">
     <id>org.zalando.intellij.swagger.examples.extensions.zalando</id>
-    <name>Zalando Extensions</name>
+    <name>Swagger Plugin [Zalando Extensions]</name>
     <version>0.0.1</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
     <depends>org.zalando.intellij.swagger</depends>
 
     <description><![CDATA[
-        Example plugin that uses intellij-swagger extension points.
+        The plugin includes features that are relevant in the Zalando development environment,
+        such as <a href="https://opensource.zalando.com/zally">Zally</a> linting.
     ]]></description>
 
     <idea-version since-build="145"/>

--- a/examples/extensions-zalando/src/main/resources/inspectionDescriptions/YamlFileValidator.html
+++ b/examples/extensions-zalando/src/main/resources/inspectionDescriptions/YamlFileValidator.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<p>The API does not follow some of the REST guidelines.</p>
+<!-- tooltip end -->
+<p>Zally inspection.</p>
+</body>
+</html>

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/SwaggerLightCodeInsightFixtureTestCase.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/SwaggerLightCodeInsightFixtureTestCase.java
@@ -1,0 +1,30 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando;
+
+import com.google.common.base.Preconditions;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public abstract class SwaggerLightCodeInsightFixtureTestCase extends LightCodeInsightFixtureTestCase {
+
+    @NotNull
+    @Override
+    protected String getTestDataPath() {
+        try {
+            return tryToGetAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    private String tryToGetAbsolutePath() throws URISyntaxException {
+        final URL url = ClassLoader.getSystemClassLoader().getResource("testing/");
+        Preconditions.checkNotNull(url);
+        return new File(url.toURI()).getAbsolutePath();
+    }
+
+}

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 public class MockZallyService implements ZallyService {
 
-    public LintingResponse validate(final String spec) {
+    public LintingResponse lint(final String spec) {
         final Set<Violation> violations = new HashSet<>();
         violations.add(new Violation("Violation 1", "MUST", "Violation link"));
 

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
@@ -1,0 +1,18 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
+
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponse;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.Violation;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MockZallyService implements ZallyService {
+
+    public LintingResponse validate(final String spec) {
+        final Set<Violation> violations = new HashSet<>();
+        violations.add(new Violation("Violation 1", "MUST", "Violation link"));
+
+        return new LintingResponse(violations);
+    }
+
+}

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidatorTest.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/YamlFileValidatorTest.java
@@ -1,0 +1,16 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
+
+import com.intellij.mock.MockComponentManager;
+import org.zalando.intellij.swagger.examples.extensions.zalando.SwaggerLightCodeInsightFixtureTestCase;
+
+public class YamlFileValidatorTest extends SwaggerLightCodeInsightFixtureTestCase {
+
+    private void doTest(final String fileName) {
+        myFixture.enableInspections(new YamlFileValidator());
+        myFixture.testHighlighting(true, false, false, "zally/" + fileName);
+    }
+
+    public void testUnknownRootField() {
+        doTest("yaml/swagger.yaml");
+    }
+}

--- a/examples/extensions-zalando/src/test/resources/testing/zally/yaml/swagger.yaml
+++ b/examples/extensions-zalando/src/test/resources/testing/zally/yaml/swagger.yaml
@@ -1,0 +1,4 @@
+<error descr="[MUST] Violation 1">swagger:</error> '2.0'
+info:
+  version: 0.0.1
+  title: Test Spec


### PR DESCRIPTION
This commit enables Zally validation. A user must
configure a Zally URL where the YAML spec is sent.

A user must also have a `ztoken` command available in
order for the plugin to create authenticated requests
to the Zally API.