### PR TITLE
Enabled Zally for OpenAPI 3 specs

### DIFF
--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/OpenApiYamlFileValidator.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/OpenApiYamlFileValidator.java
@@ -1,0 +1,41 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
+
+import com.intellij.codeInspection.InspectionManager;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.file.FileDetector;
+import org.zalando.intellij.swagger.traversal.path.PathFinder;
+
+import java.util.Optional;
+
+public class OpenApiYamlFileValidator extends ZallyYamlFileValidator {
+
+    private final FileDetector fileDetector = new FileDetector();
+    private final PathFinder pathFinder = new PathFinder();
+
+    public OpenApiYamlFileValidator() {
+        this(ServiceManager.getService(ZallyService.class));
+    }
+
+    public OpenApiYamlFileValidator(ZallyService zallyService) {
+        super(zallyService);
+    }
+
+    @Override
+    public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
+        return checkViolations(file, manager, isOnTheFly);
+    }
+
+    public boolean supportsFile(final PsiFile file) {
+        return fileDetector.isMainOpenApiYamlFile(file);
+    }
+
+    @Override
+    Optional<PsiElement> getRootElement(final PsiFile file) {
+        return pathFinder.findByPathFrom("$.openapi", file);
+    }
+
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/SwaggerYamlFileValidator.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/SwaggerYamlFileValidator.java
@@ -1,0 +1,41 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
+
+import com.intellij.codeInspection.InspectionManager;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.file.FileDetector;
+import org.zalando.intellij.swagger.traversal.path.PathFinder;
+
+import java.util.Optional;
+
+public class SwaggerYamlFileValidator extends ZallyYamlFileValidator {
+
+    private final FileDetector fileDetector = new FileDetector();
+    private final PathFinder pathFinder = new PathFinder();
+
+    public SwaggerYamlFileValidator() {
+        this(ServiceManager.getService(ZallyService.class));
+    }
+
+    public SwaggerYamlFileValidator(ZallyService zallyService) {
+        super(zallyService);
+    }
+
+    @Override
+    public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
+        return checkViolations(file, manager, isOnTheFly);
+    }
+
+    public boolean supportsFile(final PsiFile file) {
+        return fileDetector.isMainSwaggerYamlFile(file);
+    }
+
+    @Override
+    Optional<PsiElement> getRootElement(final PsiFile file) {
+        return pathFinder.findByPathFrom("$.swagger", file);
+    }
+
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyYamlFileValidator.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyYamlFileValidator.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public abstract class ZallyYamlFileValidator extends LocalInspectionTool {
 
-    private final static Logger LOG = Logger.getInstance(OpenApiYamlFileValidator.class);
+    private final static Logger LOG = Logger.getInstance(ZallyYamlFileValidator.class);
 
     private final ZallyService zallyService;
 

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>org.zalando.intellij.swagger.examples.extensions.zalando</id>
     <name>Swagger Plugin [Zalando Extensions]</name>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
     <depends>org.zalando.intellij.swagger</depends>
@@ -20,8 +20,11 @@
 
     <extensions defaultExtensionNs="com.intellij">
 
-        <localInspection displayName="Zally Validator" groupName="OpenAPI Validation"  enabledByDefault="true" language="yaml"
-                         implementationClass="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.YamlFileValidator"/>
+        <localInspection displayName="Zally Swagger Validator" groupName="Swagger Validation"  enabledByDefault="true" language="yaml"
+                         implementationClass="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.SwaggerYamlFileValidator"/>
+
+        <localInspection displayName="Zally Open API Validator" groupName="OpenAPI Validation"  enabledByDefault="true" language="yaml"
+                         implementationClass="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.OpenApiYamlFileValidator"/>
 
         <applicationService serviceInterface="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.ZallyService"
                             serviceImplementation="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.http.HttpZallyService"

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/SwaggerYamlFileValidatorTest.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/SwaggerYamlFileValidatorTest.java
@@ -1,12 +1,11 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
 
-import com.intellij.mock.MockComponentManager;
 import org.zalando.intellij.swagger.examples.extensions.zalando.SwaggerLightCodeInsightFixtureTestCase;
 
-public class YamlFileValidatorTest extends SwaggerLightCodeInsightFixtureTestCase {
+public class SwaggerYamlFileValidatorTest extends SwaggerLightCodeInsightFixtureTestCase {
 
     private void doTest(final String fileName) {
-        myFixture.enableInspections(new YamlFileValidator());
+        myFixture.enableInspections(new SwaggerYamlFileValidator());
         myFixture.testHighlighting(true, false, false, "zally/" + fileName);
     }
 


### PR DESCRIPTION
This commit introduces Zally linting for OpenAPI 3
specifications.