### PR TITLE
Disabled Zally linting on save

### DIFF
--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/DefaultZallySettings.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/DefaultZallySettings.java
@@ -1,0 +1,35 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.Nullable;
+
+@State(name = "SwaggerSetting",
+        storages = @Storage("intellij-swagger.xml"))
+public class DefaultZallySettings implements PersistentStateComponent<DefaultZallySettings>, ZallySettings {
+
+    public String zallyUrl;
+
+    @Nullable
+    @Override
+    public DefaultZallySettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(DefaultZallySettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+
+    @Override
+    public String getZallyUrl() {
+        return zallyUrl;
+    }
+
+    @Override
+    public void setZallyUrl(String zallyUrl) {
+        this.zallyUrl = zallyUrl;
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettings.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettings.java
@@ -1,25 +1,8 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.validator;
 
-import com.intellij.openapi.components.PersistentStateComponent;
-import com.intellij.openapi.components.State;
-import com.intellij.openapi.components.Storage;
-import com.intellij.util.xmlb.XmlSerializerUtil;
-import org.jetbrains.annotations.Nullable;
+public interface ZallySettings {
 
-@State(name = "SwaggerSetting",
-        storages = @Storage("intellij-swagger.xml"))
-public class ZallySettings implements PersistentStateComponent<ZallySettings> {
+    String getZallyUrl();
 
-    public String zallyUrl;
-
-    @Nullable
-    @Override
-    public ZallySettings getState() {
-        return this;
-    }
-
-    @Override
-    public void loadState(ZallySettings state) {
-        XmlSerializerUtil.copyBean(state, this);
-    }
+    void setZallyUrl(String zallyUrl);
 }

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettingsGui.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettingsGui.java
@@ -58,23 +58,23 @@ public class ZallySettingsGui implements SearchableConfigurable {
     public boolean isModified() {
         final ZallySettings settings = ServiceManager.getService(ZallySettings.class);
 
-        return (settings.zallyUrl != null &&
-                !settings.zallyUrl.equals(zallyUrlTextField.getText())) ||
-                settings.zallyUrl == null && zallyUrlTextField.getText() != null;
+        return (settings.getZallyUrl() != null &&
+                !settings.getZallyUrl().equals(zallyUrlTextField.getText())) ||
+                settings.getZallyUrl() == null && zallyUrlTextField.getText() != null;
     }
 
     @Override
     public void apply() throws ConfigurationException {
         final ZallySettings settings = ServiceManager.getService(ZallySettings.class);
 
-        settings.zallyUrl = zallyUrlTextField.getText();
+        settings.setZallyUrl(zallyUrlTextField.getText());
     }
 
     @Override
     public void reset() {
         final ZallySettings settings = ServiceManager.getService(ZallySettings.class);
 
-        zallyUrlTextField.setText(settings.zallyUrl);
+        zallyUrlTextField.setText(settings.getZallyUrl());
     }
 
     @Override

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/HttpZallyService.java
@@ -13,6 +13,7 @@ import feign.Logger;
 import feign.codec.Decoder;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.DefaultZallySettings;
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings;
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.ZallyService;
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingRequest;
@@ -48,7 +49,7 @@ public class HttpZallyService implements ZallyService {
     }
 
     private static ZallyApi connect() {
-        final String zallyUrl = ServiceManager.getService(ZallySettings.class).zallyUrl;
+        final String zallyUrl = ServiceManager.getService(ZallySettings.class).getZallyUrl();
 
         final Gson gson = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingResponse.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/LintingResponse.java
@@ -1,16 +1,16 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model;
 
-import java.util.Set;
+import java.util.List;
 
 public class LintingResponse {
 
-    private final Set<Violation> violations;
+    private final List<Violation> violations;
 
-    public LintingResponse(Set<Violation> violations) {
+    public LintingResponse(List<Violation> violations) {
         this.violations = violations;
     }
 
-    public Set<Violation> getViolations() {
+    public List<Violation> getViolations() {
         return violations;
     }
 }

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/Violation.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/model/Violation.java
@@ -1,17 +1,19 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model;
 
-import com.google.common.base.Objects;
+import java.util.List;
 
 public class Violation {
 
     final private String title;
     final private String violationType;
     final private String ruleLink;
+    final private List<String> paths;
 
-    public Violation(String title, String violationType, String ruleLink) {
+    public Violation(String title, String violationType, String ruleLink, List<String> paths) {
         this.title = title;
         this.violationType = violationType;
         this.ruleLink = ruleLink;
+        this.paths = paths;
     }
 
     public String getTitle() {
@@ -26,18 +28,7 @@ public class Violation {
         return ruleLink;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Violation violation = (Violation) o;
-        return Objects.equal(title, violation.title) &&
-                Objects.equal(violationType, violation.violationType) &&
-                Objects.equal(ruleLink, violation.ruleLink);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(title, violationType, ruleLink);
+    public List<String> getPaths() {
+        return paths;
     }
 }

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -20,10 +20,10 @@
 
     <extensions defaultExtensionNs="com.intellij">
 
-        <localInspection displayName="Zally Swagger Validator" groupName="Swagger Validation"  enabledByDefault="true" language="yaml"
+        <localInspection displayName="Zally Swagger Validator" groupName="Swagger Validation" language="yaml"
                          implementationClass="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.SwaggerYamlFileValidator"/>
 
-        <localInspection displayName="Zally Open API Validator" groupName="OpenAPI Validation"  enabledByDefault="true" language="yaml"
+        <localInspection displayName="Zally Open API Validator" groupName="OpenAPI Validation" language="yaml"
                          implementationClass="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.OpenApiYamlFileValidator"/>
 
         <applicationService serviceInterface="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.ZallyService"
@@ -34,6 +34,9 @@
                              displayName="Zally"
                              id="preferences.zally"
                              instance="org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettingsGui" />
-        <applicationService serviceImplementation="org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings"/>
+        <applicationService
+                serviceInterface="org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings"
+                serviceImplementation="org.zalando.intellij.swagger.examples.extensions.zalando.validator.DefaultZallySettings"
+                testServiceImplementation="org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.MockZallySettings"/>
     </extensions>
 </idea-plugin>

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
@@ -1,16 +1,22 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
 
+import com.google.common.collect.ImmutableList;
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.LintingResponse;
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.Violation;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class MockZallyService implements ZallyService {
 
     public LintingResponse lint(final String spec) {
-        final Set<Violation> violations = new HashSet<>();
-        violations.add(new Violation("Violation 1", "MUST", "Violation link"));
+        final List<String> paths = ImmutableList.of("a/path");
+
+        final List<Violation> violations = ImmutableList.of(
+                new Violation("Violation 1", "MUST", "Violation link", paths)
+        );
 
         return new LintingResponse(violations);
     }

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallySettings.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallySettings.java
@@ -1,0 +1,16 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
+
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings;
+
+public class MockZallySettings implements ZallySettings {
+
+    @Override
+    public String getZallyUrl() {
+        return "http://localhost";
+    }
+
+    @Override
+    public void setZallyUrl(String zallyUrl) {
+        // Not needed for a mock, no test cases for it.
+    }
+}

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/SwaggerYamlFileValidatorTest.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/SwaggerYamlFileValidatorTest.java
@@ -1,15 +1,17 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally;
 
+import com.intellij.codeInspection.ex.LocalInspectionToolWrapper;
 import org.zalando.intellij.swagger.examples.extensions.zalando.SwaggerLightCodeInsightFixtureTestCase;
 
 public class SwaggerYamlFileValidatorTest extends SwaggerLightCodeInsightFixtureTestCase {
 
-    private void doTest(final String fileName) {
-        myFixture.enableInspections(new SwaggerYamlFileValidator());
-        myFixture.testHighlighting(true, false, false, "zally/" + fileName);
+    public void testZallyViolationsAreReported() {
+        final SwaggerYamlFileValidator swaggerYamlFileValidator = new SwaggerYamlFileValidator();
+
+        myFixture.enableInspections(swaggerYamlFileValidator);
+
+        final LocalInspectionToolWrapper toolWrapper = new LocalInspectionToolWrapper(swaggerYamlFileValidator);
+        myFixture.testInspection("zally/yaml/", toolWrapper);
     }
 
-    public void testUnknownRootField() {
-        doTest("yaml/swagger.yaml");
-    }
 }

--- a/examples/extensions-zalando/src/test/resources/testing/zally/yaml/expected.xml
+++ b/examples/extensions-zalando/src/test/resources/testing/zally/yaml/expected.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<problems>
+    <problem>
+        <file>swagger.yaml</file>
+        <line>1</line>
+        <description>[MUST] Violation 1 Location: (a/path)</description>
+    </problem>
+</problems>
+

--- a/examples/extensions-zalando/src/test/resources/testing/zally/yaml/src/swagger.yaml
+++ b/examples/extensions-zalando/src/test/resources/testing/zally/yaml/src/swagger.yaml
@@ -1,0 +1,4 @@
+swagger: '2.0'
+info:
+  version: 0.0.1
+  title: Test Spec

--- a/examples/extensions-zalando/src/test/resources/testing/zally/yaml/swagger.yaml
+++ b/examples/extensions-zalando/src/test/resources/testing/zally/yaml/swagger.yaml
@@ -1,4 +1,0 @@
-<error descr="[MUST] Violation 1">swagger:</error> '2.0'
-info:
-  version: 0.0.1
-  title: Test Spec


### PR DESCRIPTION
Instead of linting on every save, require users to manually
trigger Zally validation.

![image](https://user-images.githubusercontent.com/1151536/46411194-ce13ff80-c723-11e8-959e-6d569596f350.png)

![image](https://user-images.githubusercontent.com/1151536/46411206-d3714a00-c723-11e8-8fb6-b12c00737e47.png)
