### PR TITLE
Improvements for Swagger UI generation

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/file/SwaggerUiCreator.java
+++ b/src/main/java/org/zalando/intellij/swagger/file/SwaggerUiCreator.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
@@ -20,12 +21,12 @@ public class SwaggerUiCreator {
         this.fileContentManipulator = fileContentManipulator;
     }
 
-    public Optional<String> createSwaggerUiFiles(final String specificationContent) throws Exception {
+    public Path createSwaggerUiFiles(final String specificationContent) throws Exception {
         final File tempSwaggerUiDir = copySwaggerUiToTempDir();
 
         setSwaggerConfigurationValues(new File(tempSwaggerUiDir, "index.html"), specificationContent);
 
-        return Optional.of(tempSwaggerUiDir.getAbsolutePath());
+        return Paths.get(tempSwaggerUiDir.getAbsolutePath());
     }
 
     public void updateSwaggerUiFile(final LocalFileUrl indexFileUrl, final String specificationContent) {


### PR DESCRIPTION
This commit introduces two improvements:

1) If the Swagger UI generation fails, show a notification
*only* if the user has clicked on the browser icon. Do
not display Swagger UI errors on save eventi. A user may
save an invalid file multiple times; showing a notification
on each save does not provide value.

2) If a user clicks the browser icon to view Swagger UI, always
create a new UI instead of using a cached version. A cached version
might not always contain all the necessary files, so we need to provide
a way for users to generate fresh ones (without restarting IDE).

Part of #190