### PR TITLE
Added missing `items` auto completion

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
@@ -40,7 +40,8 @@ public class MainPathResolver implements PathResolver {
     public final boolean childOfParameterItems(final PsiElement psiElement) {
         return hasPath(psiElement, "$.paths.*.*.parameters.items") ||
                 hasPath(psiElement, "$.paths.*.*.responses.*.headers.*.items") ||
-                hasPath(psiElement, "$.paths.*.parameters.items");
+                hasPath(psiElement, "$.paths.*.parameters.items") ||
+                hasPath(psiElement, "$.parameters.**.items");
     }
 
     public final boolean childOfResponses(final PsiElement psiElement) {

--- a/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
@@ -179,6 +179,15 @@ public class SwaggerCompletionTest extends JsonAndYamlCompletionTest {
     }
 
     @Test
+    public void thatItemsKeysInParameterDefinitionsAreSuggested() {
+        getCaretCompletions("items_in_parameter_definitions")
+                .assertContains("type", "format", "items", "collectionFormat", "default", "maximum",
+                        "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern",
+                        "maxItems", "minItems", "uniqueItems", "multipleOf")
+                .isOfSize(17);
+    }
+
+    @Test
     public void thatResponsesKeysAreSuggested() {
         getCaretCompletions("responses")
                 .assertContains("default", "200", "201")

--- a/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/completion/field/completion/swagger/SwaggerCompletionTest.java
@@ -181,7 +181,7 @@ public class SwaggerCompletionTest extends JsonAndYamlCompletionTest {
     @Test
     public void thatItemsKeysInParameterDefinitionsAreSuggested() {
         getCaretCompletions("items_in_parameter_definitions")
-                .assertContains("type", "format", "items", "collectionFormat", "default", "maximum",
+                .assertContains("enum", "type", "format", "items", "collectionFormat", "default", "maximum",
                         "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern",
                         "maxItems", "minItems", "uniqueItems", "multipleOf")
                 .isOfSize(17);

--- a/src/test/resources/testing/completion/field/swagger/items_in_parameter_definitions.json
+++ b/src/test/resources/testing/completion/field/swagger/items_in_parameter_definitions.json
@@ -1,0 +1,10 @@
+{
+  "swagger": "2.0",
+  "parameters": {
+    "Dog": {
+      "items": {
+        <caret>
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/completion/field/swagger/items_in_parameter_definitions.yaml
+++ b/src/test/resources/testing/completion/field/swagger/items_in_parameter_definitions.yaml
@@ -1,0 +1,5 @@
+swagger: '2.0'
+parameters:
+  Dog:
+    items:
+      <caret>


### PR DESCRIPTION
This commit adds auto completion in the following case:

```yaml
swagger: '2.0'
parameters:
  Dog:
    items:
      <caret>
```

Fixes #198