### PR TITLE
Added a template for new Swagger/OpenAPI files

### DIFF
--- a/src/main/java/CreateSwaggerFile.java
+++ b/src/main/java/CreateSwaggerFile.java
@@ -1,0 +1,29 @@
+import com.intellij.ide.actions.CreateFileFromTemplateAction;
+import com.intellij.ide.actions.CreateFileFromTemplateDialog;
+import com.intellij.json.JsonFileType;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDirectory;
+import org.jetbrains.yaml.YAMLFileType;
+
+public class CreateSwaggerFile extends CreateFileFromTemplateAction implements DumbAware {
+
+    public CreateSwaggerFile() {
+        super("Swagger/OpenAPI File", "Create a Swagger or an OpenAPI file from the specified template", null);
+    }
+
+    @Override
+    protected void buildDialog(Project project, PsiDirectory directory, CreateFileFromTemplateDialog.Builder builder) {
+        builder
+                .setTitle("New API Specification")
+                .addKind("Swagger file (YAML)", YAMLFileType.YML.getIcon(), "Swagger File (YAML).yaml")
+                .addKind("Swagger file (JSON)", JsonFileType.INSTANCE.getIcon(), "Swagger File (JSON).json")
+                .addKind("OpenAPI file (YAML)", YAMLFileType.YML.getIcon(), "OpenAPI File (YAML).yaml")
+                .addKind("OpenAPI file (JSON)", JsonFileType.INSTANCE.getIcon(), "OpenAPI File (JSON).json");
+    }
+
+    @Override
+    protected String getActionName(PsiDirectory directory, String newName, String templateName) {
+        return "Create API Specification " + newName;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -49,5 +49,16 @@
         <fileBasedIndex implementation="org.zalando.intellij.swagger.index.openapi.OpenApiFileIndex" />
 
         <applicationService serviceImplementation="org.zalando.intellij.swagger.service.SwaggerFileService" />
+
+        <internalFileTemplate name="Swagger File (JSON)"/>
+        <internalFileTemplate name="Swagger File (YAML)"/>
+        <internalFileTemplate name="OpenAPI File (JSON)"/>
+        <internalFileTemplate name="OpenAPI File (YAML)"/>
     </extensions>
+    <actions>
+        <action id="SwaggerPlugin.CreateSwaggerFile" class="CreateSwaggerFile" text="Swagger/OpenAPI File"
+                description="Create a Swagger or an OpenAPI file">
+            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="CreateResourceBundle"/>
+        </action>
+    </actions>
 </idea-plugin>

--- a/src/main/resources/fileTemplates/internal/OpenAPI File (JSON).json.ft
+++ b/src/main/resources/fileTemplates/internal/OpenAPI File (JSON).json.ft
@@ -1,0 +1,26 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Sample API",
+    "description": "API description in Markdown.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Returns a list of users.",
+        "description": "Optional extended description in Markdown.",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/fileTemplates/internal/OpenAPI File (JSON).json.ft
+++ b/src/main/resources/fileTemplates/internal/OpenAPI File (JSON).json.ft
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.0.1",
   "info": {
     "title": "Sample API",
     "description": "API description in Markdown.",

--- a/src/main/resources/fileTemplates/internal/OpenAPI File (YAML).yaml.ft
+++ b/src/main/resources/fileTemplates/internal/OpenAPI File (YAML).yaml.ft
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.0.1
 info:
   title: Sample API
   description: API description in Markdown.

--- a/src/main/resources/fileTemplates/internal/OpenAPI File (YAML).yaml.ft
+++ b/src/main/resources/fileTemplates/internal/OpenAPI File (YAML).yaml.ft
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+servers:
+  - url: 'https://api.example.com'
+paths:
+  /users:
+    get:
+      summary: Returns a list of users.
+      description: Optional extended description in Markdown.
+      responses:
+        '200':
+          description: OK

--- a/src/main/resources/fileTemplates/internal/Swagger File (JSON).json.ft
+++ b/src/main/resources/fileTemplates/internal/Swagger File (JSON).json.ft
@@ -1,0 +1,28 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Sample API",
+    "description": "API description in Markdown.",
+    "version": "1.0.0"
+  },
+  "host": "api.example.com",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Returns a list of users.",
+        "description": "Optional extended description in Markdown.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/fileTemplates/internal/Swagger File (YAML).yaml.ft
+++ b/src/main/resources/fileTemplates/internal/Swagger File (YAML).yaml.ft
@@ -1,0 +1,18 @@
+swagger: "2.0"
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+host: api.example.com
+schemes:
+  - https
+paths:
+  /users:
+    get:
+      summary: Returns a list of users.
+      description: Optional extended description in Markdown.
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK


### PR DESCRIPTION
This commit introduces a feature that allows users
to create a new Swagger/OpenAPI specification file
from the context menu (in "New").

Fixes #33 

![image](https://user-images.githubusercontent.com/1151536/47292569-154d2c00-d610-11e8-9d3f-19dfb8f64bed.png)
