### PR TITLE
Fixed Zally error PSI element fallback

### DIFF
--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>org.zalando.intellij.swagger.examples.extensions.zalando</id>
     <name>Swagger Plugin [Zalando Extensions]</name>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
     <depends>org.zalando.intellij.swagger</depends>

--- a/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
+++ b/examples/extensions-zalando/src/test/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/MockZallyService.java
@@ -10,7 +10,8 @@ public class MockZallyService implements ZallyService {
 
     public LintingResponse lint(final String spec) {
         final List<Violation> violations = ImmutableList.of(
-                new Violation("Violation 1", "Description", "MUST", "Violation link", "a/path")
+                new Violation("Violation 1", "Description", "MUST", "Violation link", "a/path"),
+                new Violation("Violation 2", "Title", "MUST", "Violation link", "/info/title")
         );
 
         return new LintingResponse(violations);

--- a/examples/extensions-zalando/src/test/resources/testing/zally/yaml/expected.xml
+++ b/examples/extensions-zalando/src/test/resources/testing/zally/yaml/expected.xml
@@ -5,5 +5,10 @@
         <line>1</line>
         <description>[MUST] Violation 1. Description</description>
     </problem>
+    <problem>
+        <file>swagger.yaml</file>
+        <line>4</line>
+        <description>[MUST] Violation 2. Title</description>
+    </problem>
 </problems>
 


### PR DESCRIPTION
The element lookup did not work correctly when looking for
`swagger` element. This commit fixes the issue and adds tests
to both cases; an error with a matching PSI element and a fallback to root element.