### PR TITLE
Wrap reads in runReadAction for external threads

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.LocalFileUrl;
 import java.nio.file.Path;
@@ -39,16 +40,18 @@ public class SwaggerFileService {
 
   public void convertSwaggerToHtmlAsync(@NotNull final PsiFile file) {
     executorService.submit(
-        () -> {
-          try {
-            convertSwaggerToHtmlWithCache(file, convertToJsonIfNecessary(file));
-          } catch (Exception e) {
-            // This is a no-op; we don't want to notify the user if the
-            // Swagger UI generation fails on file save. A user may
-            // edit a spec file that is invalid on multiple saves, and
-            // this would result in a large number of notifications.
-          }
-        });
+        () -> ApplicationManager.getApplication()
+            .runReadAction(
+                () -> {
+                  try {
+                    convertSwaggerToHtmlWithCache(file, convertToJsonIfNecessary(file));
+                  } catch (Exception e) {
+                    // This is a no-op; we don't want to notify the user if the
+                    // Swagger UI generation fails on file save. A user may
+                    // edit a spec file that is invalid on multiple saves, and
+                    // this would result in a large number of notifications.
+                  }
+                }));
   }
 
   private void notifyFailure(final Exception exception) {

--- a/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
@@ -40,18 +40,19 @@ public class SwaggerFileService {
 
   public void convertSwaggerToHtmlAsync(@NotNull final PsiFile file) {
     executorService.submit(
-        () -> ApplicationManager.getApplication()
-            .runReadAction(
-                () -> {
-                  try {
-                    convertSwaggerToHtmlWithCache(file, convertToJsonIfNecessary(file));
-                  } catch (Exception e) {
-                    // This is a no-op; we don't want to notify the user if the
-                    // Swagger UI generation fails on file save. A user may
-                    // edit a spec file that is invalid on multiple saves, and
-                    // this would result in a large number of notifications.
-                  }
-                }));
+        () ->
+            ApplicationManager.getApplication()
+                .runReadAction(
+                    () -> {
+                      try {
+                        convertSwaggerToHtmlWithCache(file, convertToJsonIfNecessary(file));
+                      } catch (Exception e) {
+                        // This is a no-op; we don't want to notify the user if the
+                        // Swagger UI generation fails on file save. A user may
+                        // edit a spec file that is invalid on multiple saves, and
+                        // this would result in a large number of notifications.
+                      }
+                    }));
   }
 
   private void notifyFailure(final Exception exception) {


### PR DESCRIPTION
When calling PSI related APIs in an external thread, we need
to wrap the execution in a `runReadAction()`. This is relevant,
because the Swagger UI is generated in a background thread.

Fixes #205