### PR TITLE
Renamed plugin to "Swagger"

### DIFF
--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin version="2">
     <id>org.zalando.intellij.swagger.examples.extensions.zalando</id>
-    <name>Swagger Plugin [Zalando Extensions]</name>
+    <name>Swagger [Zalando Extensions]</name>
     <version>0.0.3</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin version="2">
     <id>org.zalando.intellij.swagger</id>
-    <name>Swagger Plugin</name>
+    <name>Swagger</name>
     <version>1.0.19</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 


### PR DESCRIPTION
The name should not contain words such as "Plugin" or
"IntelliJ" (feedback from JetBrains).