### PR TITLE
Added documentation for references

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/documentation/ApiDocumentProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/documentation/ApiDocumentProvider.java
@@ -1,0 +1,74 @@
+package org.zalando.intellij.swagger.documentation;
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.commons.lang.StringUtils;
+import org.zalando.intellij.swagger.traversal.path.PathFinder;
+
+public abstract class ApiDocumentProvider extends AbstractDocumentationProvider {
+
+  protected String handleParameterReference(final PsiElement targetElement) {
+    final Optional<String> name =
+        getUnquotedFieldValue(targetElement, "name").map(n -> "name: " + n);
+
+    final String inValue = getUnquotedFieldValue(targetElement, "in").orElse("undefined location");
+    final String in = String.format("in: %s", inValue);
+
+    final Optional<String> description = getUnquotedFieldValue(targetElement, "description");
+
+    return toHtml(Stream.of(name, Optional.of(in), description));
+  }
+
+  protected String handleResponseReference(final PsiElement targetElement) {
+    final Optional<String> description = getUnquotedFieldValue(targetElement, "description");
+
+    return toHtml(Stream.of(description));
+  }
+
+  protected String handleSchemaReference(
+      final PsiElement targetElement, final PsiElement originalElement) {
+    final Optional<String> type = getType(targetElement, originalElement);
+    final Optional<String> title = getUnquotedFieldValue(targetElement, "title");
+    final Optional<String> description = getUnquotedFieldValue(targetElement, "description");
+
+    return toHtml(Stream.of(type, title, description));
+  }
+
+  private Optional<String> getType(
+      final PsiElement targetElement, final PsiElement originalElement) {
+    final String unquotedText = StringUtil.unquoteString(originalElement.getText());
+
+    final Optional<String> refName =
+        Optional.of(StringUtils.substringAfterLast(unquotedText, "/"))
+            .map(v -> v.isEmpty() ? unquotedText : v);
+
+    return refName.map(
+        name -> {
+          String type = getUnquotedFieldValue(targetElement, "type").orElse("undefined type");
+          return String.format("%s: %s", name, type);
+        });
+  }
+
+  protected String toHtml(Stream<Optional<String>> streamOfItems) {
+    final Optional<String> doc =
+        streamOfItems
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .reduce((left, right) -> left + "<br/>" + right)
+            .map(content -> "<div>" + content + "</div>");
+
+    return doc.orElse(null);
+  }
+
+  protected Optional<String> getUnquotedFieldValue(
+      final PsiElement targetElement, final String fieldName) {
+    return new PathFinder()
+        .findByPathFrom(fieldName, targetElement)
+        .map(PsiElement::getLastChild)
+        .map(PsiElement::getText)
+        .map(StringUtil::unquoteString);
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/documentation/openapi/OpenApiDocumentationProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/documentation/openapi/OpenApiDocumentationProvider.java
@@ -1,0 +1,98 @@
+package org.zalando.intellij.swagger.documentation.openapi;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.Nullable;
+import org.zalando.intellij.swagger.documentation.ApiDocumentProvider;
+import org.zalando.intellij.swagger.file.OpenApiFileType;
+import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
+import org.zalando.intellij.swagger.traversal.path.openapi.PathResolver;
+import org.zalando.intellij.swagger.traversal.path.openapi.PathResolverFactory;
+
+public class OpenApiDocumentationProvider extends ApiDocumentProvider {
+
+  private final OpenApiIndexService openApiIndexService = new OpenApiIndexService();
+
+  @Nullable
+  @Override
+  public String getQuickNavigateInfo(
+      final PsiElement targetElement, final PsiElement originalElement) {
+
+    Optional<PsiFile> psiFile =
+        Optional.ofNullable(targetElement).map(PsiElement::getContainingFile);
+
+    final Optional<VirtualFile> maybeVirtualFile = psiFile.map(PsiFile::getVirtualFile);
+    final Optional<Project> maybeProject = psiFile.map(PsiFile::getProject);
+
+    return maybeVirtualFile
+        .map(
+            virtualFile -> {
+              final Project project = maybeProject.get();
+
+              final boolean isMainOpenApiFile =
+                  openApiIndexService.isMainOpenApiFile(virtualFile, project);
+
+              final boolean isPartialOpenApiFile =
+                  openApiIndexService.isPartialOpenApiFile(virtualFile, project);
+
+              if (isMainOpenApiFile || isPartialOpenApiFile) {
+
+                final OpenApiFileType openApiFileType =
+                    isMainOpenApiFile
+                        ? OpenApiFileType.MAIN
+                        : openApiIndexService.getOpenApiFileType(virtualFile, project);
+
+                final PathResolver pathResolver =
+                    PathResolverFactory.fromOpenApiFileType(openApiFileType);
+
+                if (pathResolver.childOfSchema(targetElement)) {
+                  return handleSchemaReference(targetElement, originalElement);
+                } else if (pathResolver.childOfResponse(targetElement)) {
+                  return handleResponseReference(targetElement);
+                } else if (pathResolver.childOfParameters(targetElement)) {
+                  return handleParameterReference(targetElement);
+                } else if (pathResolver.childOfExample(targetElement)) {
+                  return handleExampleReference(targetElement);
+                } else if (pathResolver.childOfRequestBody(targetElement)) {
+                  return handleRequestBodyReference(targetElement);
+                } else if (pathResolver.childOfHeader(targetElement)) {
+                  return handleHeaderReference(targetElement);
+                } else if (pathResolver.childOfLink(targetElement)) {
+                  return handleLinkReference(targetElement);
+                }
+              }
+
+              return null;
+            })
+        .orElse(null);
+  }
+
+  private String handleLinkReference(final PsiElement targetElement) {
+    final Optional<String> description = getUnquotedFieldValue(targetElement, "description");
+
+    return toHtml(Stream.of(description));
+  }
+
+  private String handleHeaderReference(final PsiElement targetElement) {
+    final Optional<String> description = getUnquotedFieldValue(targetElement, "description");
+
+    return toHtml(Stream.of(description));
+  }
+
+  private String handleRequestBodyReference(final PsiElement targetElement) {
+    final Optional<String> description = getUnquotedFieldValue(targetElement, "description");
+
+    return toHtml(Stream.of(description));
+  }
+
+  private String handleExampleReference(final PsiElement targetElement) {
+    final Optional<String> summary = getUnquotedFieldValue(targetElement, "summary");
+    final Optional<String> description = getUnquotedFieldValue(targetElement, "description");
+
+    return toHtml(Stream.of(summary, description));
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/documentation/swagger/SwaggerDocumentationProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/documentation/swagger/SwaggerDocumentationProvider.java
@@ -1,0 +1,62 @@
+package org.zalando.intellij.swagger.documentation.swagger;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import java.util.Optional;
+import org.jetbrains.annotations.Nullable;
+import org.zalando.intellij.swagger.documentation.ApiDocumentProvider;
+import org.zalando.intellij.swagger.file.SwaggerFileType;
+import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
+import org.zalando.intellij.swagger.traversal.path.swagger.PathResolver;
+import org.zalando.intellij.swagger.traversal.path.swagger.PathResolverFactory;
+
+public class SwaggerDocumentationProvider extends ApiDocumentProvider {
+
+  private final SwaggerIndexService swaggerIndexService = new SwaggerIndexService();
+
+  @Nullable
+  @Override
+  public String getQuickNavigateInfo(
+      final PsiElement targetElement, final PsiElement originalElement) {
+    Optional<PsiFile> psiFile =
+        Optional.ofNullable(targetElement).map(PsiElement::getContainingFile);
+
+    final Optional<VirtualFile> maybeVirtualFile = psiFile.map(PsiFile::getVirtualFile);
+    final Optional<Project> maybeProject = psiFile.map(PsiFile::getProject);
+
+    return maybeVirtualFile
+        .map(
+            virtualFile -> {
+              final Project project = maybeProject.get();
+
+              final boolean isMainSwaggerFile =
+                  swaggerIndexService.isMainSwaggerFile(virtualFile, project);
+
+              final boolean isPartialSwaggerFile =
+                  swaggerIndexService.isPartialSwaggerFile(virtualFile, project);
+
+              if (isMainSwaggerFile || isPartialSwaggerFile) {
+
+                final SwaggerFileType swaggerFileType =
+                    isMainSwaggerFile
+                        ? SwaggerFileType.MAIN
+                        : swaggerIndexService.getSwaggerFileType(virtualFile, project);
+
+                final PathResolver pathResolver =
+                    PathResolverFactory.fromSwaggerFileType(swaggerFileType);
+
+                if (pathResolver.childOfSchema(targetElement)) {
+                  return handleSchemaReference(targetElement, originalElement);
+                } else if (pathResolver.childOfResponseDefinition(targetElement)) {
+                  return handleResponseReference(targetElement);
+                } else if (pathResolver.childOfParameterDefinition(targetElement)) {
+                  return handleParameterReference(targetElement);
+                }
+              }
+              return null;
+            })
+        .orElse(null);
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/swagger/MainPathResolver.java
@@ -73,7 +73,7 @@ public class MainPathResolver implements PathResolver {
   }
 
   public final boolean childOfSchema(final PsiElement psiElement) {
-    return hasPath(psiElement, "$.**.schema");
+    return hasPath(psiElement, "$.**.schema") || hasPath(psiElement, "$.definitions.*");
   }
 
   public final boolean childOfSchemaItems(final PsiElement psiElement) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,9 @@
 
         <iconProvider implementation="org.zalando.intellij.swagger.file.icon.OpenApiIconProvider" id="openApiIconProvider" />
         <iconProvider implementation="org.zalando.intellij.swagger.file.icon.SwaggerIconProvider" id="swaggerIconProvider" />
+
+        <documentationProvider implementation="org.zalando.intellij.swagger.documentation.openapi.OpenApiDocumentationProvider"/>
+        <documentationProvider implementation="org.zalando.intellij.swagger.documentation.swagger.SwaggerDocumentationProvider"/>
     </extensions>
     <actions>
         <action id="SwaggerPlugin.CreateSwaggerFile" class="CreateSwaggerFile" text="Swagger/OpenAPI File"

--- a/src/test/java/org/zalando/intellij/swagger/documentation/DocumentationTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/documentation/DocumentationTest.java
@@ -1,0 +1,35 @@
+package org.zalando.intellij.swagger.documentation;
+
+import com.intellij.codeInsight.documentation.DocumentationManager;
+import com.intellij.lang.documentation.DocumentationProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
+
+public abstract class DocumentationTest extends SwaggerLightCodeInsightFixtureTestCase {
+
+  private final String filesPath;
+
+  public DocumentationTest(final String filesPath) {
+    this.filesPath = filesPath;
+  }
+
+  protected void testQuickDocumentation(final String fileName, final String expectedDocumentation) {
+    final PsiFile psiFile = myFixture.configureByFile(filesPath + fileName);
+
+    final PsiElement originalElement =
+        psiFile.findElementAt(myFixture.getEditor().getCaretModel().getOffset());
+
+    final PsiElement targetElement =
+        DocumentationManager.getInstance(getProject())
+            .findTargetElement(myFixture.getEditor(), psiFile, originalElement);
+
+    final DocumentationProvider documentationProvider =
+        DocumentationManager.getProviderFromElement(targetElement);
+
+    final String quickNavigateInfo =
+        documentationProvider.getQuickNavigateInfo(targetElement, originalElement);
+
+    assertEquals(expectedDocumentation, quickNavigateInfo);
+  }
+}

--- a/src/test/java/org/zalando/intellij/swagger/documentation/openapi/OpenApiDocumentationTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/documentation/openapi/OpenApiDocumentationTest.java
@@ -1,0 +1,112 @@
+package org.zalando.intellij.swagger.documentation.openapi;
+
+import org.zalando.intellij.swagger.documentation.DocumentationTest;
+
+public class OpenApiDocumentationTest extends DocumentationTest {
+
+  public OpenApiDocumentationTest() {
+    super("documentation/openapi");
+  }
+
+  public void testYamlSchema() {
+    final String expected = "<div>Example: object</div>";
+    testQuickDocumentation("/yaml/schema_ref.yaml", expected);
+  }
+
+  public void testJsonSchema() {
+    final String expected = "<div>Example: object</div>";
+    testQuickDocumentation("/json/schema_ref.json", expected);
+  }
+
+  public void testYamlSchemaWithDescription() {
+    final String expected = "<div>Example: object<br/>some description</div>";
+    testQuickDocumentation("/yaml/schema_ref_with_description.yaml", expected);
+  }
+
+  public void testJsonSchemaWithDescription() {
+    final String expected = "<div>Example: object<br/>some description</div>";
+    testQuickDocumentation("/json/schema_ref_with_description.json", expected);
+  }
+
+  public void testYamlSchemaWithoutType() {
+    final String expected = "<div>Example: undefined type</div>";
+    testQuickDocumentation("/yaml/schema_ref_without_type.yaml", expected);
+  }
+
+  public void testJsonSchemaWithoutType() {
+    final String expected = "<div>Example: undefined type</div>";
+    testQuickDocumentation("/json/schema_ref_without_type.json", expected);
+  }
+
+  public void testYamlResponse() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/yaml/response_ref.yaml", expected);
+  }
+
+  public void testJsonResponse() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/json/response_ref.json", expected);
+  }
+
+  public void testYamlParameter() {
+    final String expected = "<div>name: parameter_name<br/>in: query<br/>Description</div>";
+    testQuickDocumentation("/yaml/parameter_ref.yaml", expected);
+  }
+
+  public void testJsonParameter() {
+    final String expected = "<div>name: parameter_name<br/>in: query<br/>Description</div>";
+    testQuickDocumentation("/json/parameter_ref.json", expected);
+  }
+
+  public void testYamlParameterWithoutIn() {
+    final String expected =
+        "<div>name: parameter_name<br/>in: undefined location<br/>Description</div>";
+    testQuickDocumentation("/yaml/parameter_without_in_ref.yaml", expected);
+  }
+
+  public void testJsonParameterWithoutIn() {
+    final String expected =
+        "<div>name: parameter_name<br/>in: undefined location<br/>Description</div>";
+    testQuickDocumentation("/json/parameter_without_in_ref.json", expected);
+  }
+
+  public void testYamlExample() {
+    final String expected = "<div>Summary<br/>Description</div>";
+    testQuickDocumentation("/yaml/example_ref.yaml", expected);
+  }
+
+  public void testJsonExample() {
+    final String expected = "<div>Summary<br/>Description</div>";
+    testQuickDocumentation("/json/example_ref.json", expected);
+  }
+
+  public void testYamlRequestBody() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/yaml/request_body_ref.yaml", expected);
+  }
+
+  public void testJsonRequestBody() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/json/request_body_ref.json", expected);
+  }
+
+  public void testYamlHeader() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/yaml/header_ref.yaml", expected);
+  }
+
+  public void testJsonHeader() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/json/header_ref.json", expected);
+  }
+
+  public void testYamlLink() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/yaml/link_ref.yaml", expected);
+  }
+
+  public void testJsonLink() {
+    final String expected = "<div>Description</div>";
+    testQuickDocumentation("/json/link_ref.json", expected);
+  }
+}

--- a/src/test/java/org/zalando/intellij/swagger/documentation/swagger/SwaggerDocumentationTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/documentation/swagger/SwaggerDocumentationTest.java
@@ -1,0 +1,40 @@
+package org.zalando.intellij.swagger.documentation.swagger;
+
+import org.zalando.intellij.swagger.documentation.DocumentationTest;
+
+public class SwaggerDocumentationTest extends DocumentationTest {
+
+  public SwaggerDocumentationTest() {
+    super("documentation/swagger");
+  }
+
+  public void testYamlSchema() {
+    final String expected = "<div>Schema: object<br/>Description</div>";
+    testQuickDocumentation("/yaml/schema_ref.yaml", expected);
+  }
+
+  public void testJsonSchema() {
+    final String expected = "<div>Schema: object<br/>Description</div>";
+    testQuickDocumentation("/json/schema_ref.json", expected);
+  }
+
+  public void testYamlParameter() {
+    final String expected = "<div>name: parameter_name<br/>in: query<br/>Description</div>";
+    testQuickDocumentation("/yaml/parameter_ref.yaml", expected);
+  }
+
+  public void testJsonParameter() {
+    final String expected = "<div>name: parameter_name<br/>in: query<br/>Description</div>";
+    testQuickDocumentation("/json/parameter_ref.json", expected);
+  }
+
+  public void testYamlResponse() {
+    final String expected = "<div>description</div>";
+    testQuickDocumentation("/yaml/response_ref.yaml", expected);
+  }
+
+  public void testJsonResponse() {
+    final String expected = "<div>description</div>";
+    testQuickDocumentation("/json/response_ref.json", expected);
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/example_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/example_ref.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "$ref": "<caret>#/components/examples/Example"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "examples": {
+      "Example": {
+        "summary": "Summary",
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/header_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/header_ref.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/pathA": {
+      "get": {
+        "responses": {
+          "200": {
+            "headers": {
+              "x-next": {
+                "$ref": "<caret>#/components/headers/Header"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "headers": {
+      "Header": {
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/link_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/link_ref.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/pathA": {
+      "get": {
+        "responses": {
+          "200": {
+            "links": {
+              "foo": {
+                "$ref": "<caret>#/components/links/Link"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "links": {
+      "Link": {
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/parameter_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/parameter_ref.json
@@ -1,0 +1,23 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/pathA": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "<caret>#/components/parameters/Parameter"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "Parameter": {
+        "name": "parameter_name",
+        "in": "query",
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/parameter_without_in_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/parameter_without_in_ref.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/pathA": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "<caret>#/components/parameters/Parameter"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "Parameter": {
+        "name": "parameter_name",
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/request_body_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/request_body_ref.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/pathA": {
+      "get": {
+        "requestBody": {
+          "$ref": "<caret>#/components/requestBodies/Foo"
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "Foo": {
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/response_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/response_ref.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "$ref": "<caret>#/components/responses/Response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "Response": {
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/schema_ref.json
+++ b/src/test/resources/testing/documentation/openapi/json/schema_ref.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "<caret>#/components/schemas/Example"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Example": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/schema_ref_with_description.json
+++ b/src/test/resources/testing/documentation/openapi/json/schema_ref_with_description.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "<caret>#/components/schemas/Example"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Example": {
+        "type": "object",
+        "description": "some description"
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/json/schema_ref_without_type.json
+++ b/src/test/resources/testing/documentation/openapi/json/schema_ref_without_type.json
@@ -1,0 +1,26 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "<caret>#/components/schemas/Example"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Example": {
+      }
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/openapi/yaml/example_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/example_ref.yaml
@@ -1,0 +1,16 @@
+openapi: "3.0.0"
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                foo:
+                  $ref: '<caret>#/components/examples/Example'
+components:
+  examples:
+    Example:
+      summary: Summary
+      description: Description

--- a/src/test/resources/testing/documentation/openapi/yaml/header_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/header_ref.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+paths:
+  /pathA:
+    get:
+      responses:
+        200:
+          headers:
+            x-next:
+              $ref: '<caret>#/components/headers/Header'
+components:
+  headers:
+    Header:
+      description: Description
+

--- a/src/test/resources/testing/documentation/openapi/yaml/link_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/link_ref.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+paths:
+  /pathA:
+    get:
+      responses:
+        200:
+          links:
+            foo:
+              $ref: '<caret>#/components/links/Link'
+components:
+  links:
+    Link:
+      description: Description

--- a/src/test/resources/testing/documentation/openapi/yaml/parameter_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/parameter_ref.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+paths:
+  /pathA:
+    get:
+      parameters:
+        - $ref: '<caret>#/components/parameters/Parameter'
+components:
+  parameters:
+    Parameter:
+      name: parameter_name
+      in: query
+      description: Description

--- a/src/test/resources/testing/documentation/openapi/yaml/parameter_without_in_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/parameter_without_in_ref.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+paths:
+  /pathA:
+    get:
+      parameters:
+        - $ref: '<caret>#/components/parameters/Parameter'
+components:
+  parameters:
+    Parameter:
+      name: parameter_name
+      description: Description

--- a/src/test/resources/testing/documentation/openapi/yaml/request_body_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/request_body_ref.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+paths:
+  /pathA:
+    get:
+      requestBody:
+        $ref: '<caret>#/components/requestBodies/Foo'
+components:
+  requestBodies:
+    Foo:
+      description: Description

--- a/src/test/resources/testing/documentation/openapi/yaml/response_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/response_ref.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.1
+paths:
+  /users:
+    get:
+      responses:
+        200:
+          $ref: '<caret>#/components/responses/Response'
+components:
+  responses:
+    Response:
+      description: Description

--- a/src/test/resources/testing/documentation/openapi/yaml/schema_ref.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/schema_ref.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.1
+paths:
+  /users:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '<caret>#/components/schemas/Example'
+components:
+  schemas:
+    Example:
+      type: object

--- a/src/test/resources/testing/documentation/openapi/yaml/schema_ref_with_description.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/schema_ref_with_description.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.1
+paths:
+  /users:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '<caret>#/components/schemas/Example'
+components:
+  schemas:
+    Example:
+      type: object
+      description: some description

--- a/src/test/resources/testing/documentation/openapi/yaml/schema_ref_without_type.yaml
+++ b/src/test/resources/testing/documentation/openapi/yaml/schema_ref_without_type.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.1
+paths:
+  /users:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '<caret>#/components/schemas/Example'
+components:
+  schemas:
+    Example:

--- a/src/test/resources/testing/documentation/swagger/json/parameter_ref.json
+++ b/src/test/resources/testing/documentation/swagger/json/parameter_ref.json
@@ -1,0 +1,21 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "<caret>#/parameters/Parameter"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "Parameter": {
+      "name": "parameter_name",
+      "in": "query",
+      "description": "Description"
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/swagger/json/response_ref.json
+++ b/src/test/resources/testing/documentation/swagger/json/response_ref.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/path": {
+      "get": {
+        "responses": {
+          "200": {
+            "$ref": "<caret>#/responses/Response"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "Response": {
+      "description": "description"
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/swagger/json/schema_ref.json
+++ b/src/test/resources/testing/documentation/swagger/json/schema_ref.json
@@ -1,0 +1,22 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "<caret>#/definitions/Schema"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Schema": {
+      "type": "object",
+      "description": "Description"
+    }
+  }
+}

--- a/src/test/resources/testing/documentation/swagger/yaml/parameter_ref.yaml
+++ b/src/test/resources/testing/documentation/swagger/yaml/parameter_ref.yaml
@@ -1,0 +1,11 @@
+swagger: '2.0'
+paths:
+  /pets:
+    get:
+      parameters:
+        - $ref: '<caret>#/parameters/Parameter'
+parameters:
+  Parameter:
+    name: parameter_name
+    in: query
+    description: Description

--- a/src/test/resources/testing/documentation/swagger/yaml/response_ref.yaml
+++ b/src/test/resources/testing/documentation/swagger/yaml/response_ref.yaml
@@ -1,0 +1,10 @@
+swagger: '2.0'
+paths:
+  /path:
+    get:
+      responses:
+        200:
+          $ref: '<caret>#/responses/Response'
+responses:
+  Response:
+    description: description

--- a/src/test/resources/testing/documentation/swagger/yaml/schema_ref.yaml
+++ b/src/test/resources/testing/documentation/swagger/yaml/schema_ref.yaml
@@ -1,0 +1,12 @@
+swagger: '2.0'
+paths:
+  /pets:
+    get:
+      responses:
+        200:
+          schema:
+            $ref: '<caret>#/definitions/Schema'
+definitions:
+  Schema:
+    type: object
+    description: Description


### PR DESCRIPTION
This commit introduces a feature for displaying a short
description of the referenced element when the cursor is hovered
over the element. This improves the UX; it is no longer necessary
to navigate to the referenced element in order to check it's type or description
(as an example).

Example:

![image](https://user-images.githubusercontent.com/1151536/49648044-1e158800-fa2d-11e8-84e3-3db4a72364c2.png)
