### PR TITLE
Added unused component warning

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/annotator/openapi/JsonUnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/openapi/JsonUnusedRefAnnotator.java
@@ -1,0 +1,21 @@
+package org.zalando.intellij.swagger.annotator.openapi;
+
+import com.intellij.psi.PsiElement;
+import org.zalando.intellij.swagger.traversal.JsonTraversal;
+
+public class JsonUnusedRefAnnotator extends UnusedRefAnnotator {
+
+  public JsonUnusedRefAnnotator() {
+    super(new JsonTraversal());
+  }
+
+  @Override
+  public PsiElement getPsiElement(final PsiElement psiElement) {
+    return psiElement.getParent().getParent().getParent();
+  }
+
+  @Override
+  public PsiElement getSearchablePsiElement(final PsiElement psiElement) {
+    return psiElement.getParent().getParent();
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/annotator/openapi/UnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/openapi/UnusedRefAnnotator.java
@@ -1,0 +1,112 @@
+package org.zalando.intellij.swagger.annotator.openapi;
+
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.search.searches.ReferencesSearch;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.file.OpenApiFileType;
+import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
+import org.zalando.intellij.swagger.traversal.Traversal;
+import org.zalando.intellij.swagger.traversal.path.openapi.PathResolver;
+import org.zalando.intellij.swagger.traversal.path.openapi.PathResolverFactory;
+
+public abstract class UnusedRefAnnotator implements Annotator {
+
+  private final Traversal traversal;
+  private final OpenApiIndexService openApiIndexService = new OpenApiIndexService();
+
+  UnusedRefAnnotator(Traversal traversal) {
+    this.traversal = traversal;
+  }
+
+  public abstract PsiElement getPsiElement(PsiElement psiElement);
+
+  public abstract PsiElement getSearchablePsiElement(PsiElement psiElement);
+
+  @Override
+  public void annotate(
+      @NotNull final PsiElement psiElement, @NotNull final AnnotationHolder annotationHolder) {
+
+    final Optional<OpenApiFileType> maybeFileType = openApiIndexService.getFileType(psiElement);
+
+    maybeFileType.ifPresent(
+        fileType -> {
+          final PathResolver pathResolver = PathResolverFactory.fromOpenApiFileType(fileType);
+          traversal
+              .getKeyNameIfKey(psiElement)
+              .ifPresent(
+                  keyName -> {
+                    final PsiElement currentElement = getPsiElement(psiElement);
+                    PsiElement searchableCurrentElement = getSearchablePsiElement(psiElement);
+
+                    if (pathResolver.isSchema(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Schema is never used");
+                    } else if (pathResolver.isResponse(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Response is never used");
+                    } else if (pathResolver.isParameter(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Parameter is never used");
+                    } else if (pathResolver.isExample(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Example is never used");
+                    } else if (pathResolver.isRequestBody(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Request body is never used");
+                    } else if (pathResolver.isHeader(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Header is never used");
+                    } else if (pathResolver.isLink(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Link is never used");
+                    } else if (pathResolver.isCallback(currentElement)) {
+                      warn(
+                          psiElement,
+                          annotationHolder,
+                          searchableCurrentElement,
+                          "Callback is never used");
+                    }
+                  });
+        });
+  }
+
+  private void warn(
+      final PsiElement psiElement,
+      final AnnotationHolder annotationHolder,
+      final PsiElement searchableCurrentElement,
+      final String warning) {
+    final PsiReference first = ReferencesSearch.search(searchableCurrentElement).findFirst();
+
+    if (first == null) {
+      Annotation annotation = annotationHolder.createWeakWarningAnnotation(psiElement, warning);
+      annotation.setHighlightType(ProblemHighlightType.LIKE_UNUSED_SYMBOL);
+    }
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/annotator/openapi/YamlUnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/openapi/YamlUnusedRefAnnotator.java
@@ -1,0 +1,21 @@
+package org.zalando.intellij.swagger.annotator.openapi;
+
+import com.intellij.psi.PsiElement;
+import org.zalando.intellij.swagger.traversal.YamlTraversal;
+
+public class YamlUnusedRefAnnotator extends UnusedRefAnnotator {
+
+  public YamlUnusedRefAnnotator() {
+    super(new YamlTraversal());
+  }
+
+  @Override
+  public PsiElement getPsiElement(final PsiElement psiElement) {
+    return psiElement.getParent().getParent();
+  }
+
+  @Override
+  public PsiElement getSearchablePsiElement(final PsiElement psiElement) {
+    return psiElement.getParent();
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/annotator/swagger/UnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/swagger/UnusedRefAnnotator.java
@@ -4,19 +4,16 @@ import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.search.searches.ReferencesSearch;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.file.SwaggerFileType;
 import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
 import org.zalando.intellij.swagger.traversal.Traversal;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolver;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolverFactory;
-
-import java.util.Optional;
 
 public abstract class UnusedRefAnnotator implements Annotator {
 

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiJsonCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiJsonCompletionContributor.java
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.completion.CompletionContributor;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.psi.PsiElement;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.OpenApiCompletionHelper;
 import org.zalando.intellij.swagger.completion.contributor.CompletionResultSetFactory;
@@ -16,8 +17,6 @@ import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
 import org.zalando.intellij.swagger.traversal.JsonTraversal;
 import org.zalando.intellij.swagger.traversal.path.openapi.PathResolver;
 import org.zalando.intellij.swagger.traversal.path.openapi.PathResolverFactory;
-
-import java.util.Optional;
 
 public class OpenApiJsonCompletionContributor extends CompletionContributor {
 

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiYamlCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiYamlCompletionContributor.java
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.completion.CompletionContributor;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.psi.PsiElement;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.OpenApiCompletionHelper;
 import org.zalando.intellij.swagger.completion.contributor.CompletionResultSetFactory;
@@ -16,8 +17,6 @@ import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
 import org.zalando.intellij.swagger.traversal.YamlTraversal;
 import org.zalando.intellij.swagger.traversal.path.openapi.PathResolver;
 import org.zalando.intellij.swagger.traversal.path.openapi.PathResolverFactory;
-
-import java.util.Optional;
 
 public class OpenApiYamlCompletionContributor extends CompletionContributor {
 
@@ -42,8 +41,7 @@ public class OpenApiYamlCompletionContributor extends CompletionContributor {
 
     maybeFileType.ifPresent(
         fileType -> {
-          final PathResolver pathResolver =
-              PathResolverFactory.fromOpenApiFileType(fileType);
+          final PathResolver pathResolver = PathResolverFactory.fromOpenApiFileType(fileType);
 
           final PsiElement psiElement = parameters.getPosition();
 

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerJsonCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerJsonCompletionContributor.java
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.completion.CompletionContributor;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.psi.PsiElement;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.SwaggerCompletionHelper;
 import org.zalando.intellij.swagger.completion.contributor.CompletionResultSetFactory;
@@ -18,8 +19,6 @@ import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
 import org.zalando.intellij.swagger.traversal.JsonTraversal;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolver;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolverFactory;
-
-import java.util.Optional;
 
 public class SwaggerJsonCompletionContributor extends CompletionContributor {
 

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerYamlCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerYamlCompletionContributor.java
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.completion.CompletionContributor;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.psi.PsiElement;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.completion.SwaggerCompletionHelper;
 import org.zalando.intellij.swagger.completion.contributor.CompletionResultSetFactory;
@@ -18,8 +19,6 @@ import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
 import org.zalando.intellij.swagger.traversal.YamlTraversal;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolver;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolverFactory;
-
-import java.util.Optional;
 
 public class SwaggerYamlCompletionContributor extends CompletionContributor {
 

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerYamlCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerYamlCompletionContributor.java
@@ -19,6 +19,8 @@ import org.zalando.intellij.swagger.traversal.YamlTraversal;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolver;
 import org.zalando.intellij.swagger.traversal.path.swagger.PathResolverFactory;
 
+import java.util.Optional;
+
 public class SwaggerYamlCompletionContributor extends CompletionContributor {
 
   private final YamlTraversal yamlTraversal;
@@ -37,47 +39,36 @@ public class SwaggerYamlCompletionContributor extends CompletionContributor {
   @Override
   public void fillCompletionVariants(
       @NotNull CompletionParameters parameters, @NotNull CompletionResultSet result) {
-    final boolean isMainSwaggerFile =
-        swaggerIndexService.isMainSwaggerFile(
-            parameters.getOriginalFile().getVirtualFile(),
-            parameters.getOriginalFile().getProject());
 
-    final boolean isPartialSwaggerFile =
-        swaggerIndexService.isPartialSwaggerFile(
-            parameters.getOriginalFile().getVirtualFile(),
-            parameters.getOriginalFile().getProject());
+    final Optional<SwaggerFileType> maybeFileType = swaggerIndexService.getFileType(parameters);
 
-    if (isMainSwaggerFile || isPartialSwaggerFile) {
-      final PsiElement psiElement = parameters.getPosition();
-      final SwaggerFileType swaggerFileType =
-          isMainSwaggerFile
-              ? SwaggerFileType.MAIN
-              : swaggerIndexService.getSwaggerFileType(
-                  parameters.getOriginalFile().getVirtualFile(),
-                  parameters.getOriginalFile().getProject());
+    maybeFileType.ifPresent(
+        fileType -> {
+          final PathResolver pathResolver = PathResolverFactory.fromSwaggerFileType(fileType);
 
-      final PathResolver pathResolver = PathResolverFactory.fromSwaggerFileType(swaggerFileType);
+          final PsiElement psiElement = parameters.getPosition();
 
-      final SwaggerCompletionHelper completionHelper =
-          new SwaggerCompletionHelper(psiElement, yamlTraversal, pathResolver);
+          final SwaggerCompletionHelper completionHelper =
+              new SwaggerCompletionHelper(psiElement, yamlTraversal, pathResolver);
 
-      SwaggerFieldCompletionFactory.from(completionHelper, result).ifPresent(FieldCompletion::fill);
+          SwaggerFieldCompletionFactory.from(completionHelper, result)
+              .ifPresent(FieldCompletion::fill);
 
-      SwaggerValueCompletionFactory.from(
-              completionHelper, CompletionResultSetFactory.forValue(parameters, result))
-          .ifPresent(ValueCompletion::fill);
+          SwaggerValueCompletionFactory.from(
+                  completionHelper, CompletionResultSetFactory.forValue(parameters, result))
+              .ifPresent(ValueCompletion::fill);
 
-      for (SwaggerCustomFieldCompletionFactory ep :
-          SwaggerCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
-        ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
-      }
+          for (SwaggerCustomFieldCompletionFactory ep :
+              SwaggerCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
+            ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
+          }
 
-      for (SwaggerCustomValueCompletionFactory ep :
-          SwaggerCustomValueCompletionFactory.EP_NAME.getExtensions()) {
-        ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
-      }
+          for (SwaggerCustomValueCompletionFactory ep :
+              SwaggerCustomValueCompletionFactory.EP_NAME.getExtensions()) {
+            ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
+          }
 
-      result.stopHere();
-    }
+          result.stopHere();
+        });
   }
 }

--- a/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
@@ -3,6 +3,7 @@ package org.zalando.intellij.swagger.index.openapi;
 import static org.apache.commons.lang.StringUtils.substringAfterLast;
 import static org.apache.commons.lang.StringUtils.substringBeforeLast;
 
+import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
@@ -34,7 +35,7 @@ public class OpenApiIndexService {
     return partialOpenApiFiles.contains(virtualFile);
   }
 
-  public OpenApiFileType getOpenApiFileType(final VirtualFile virtualFile, final Project project) {
+  private OpenApiFileType getPartialOpenApiFileType(final VirtualFile virtualFile, final Project project) {
     final Set<String> partialOpenApiFilesWithTypeInfo = getPartialOpenApiFilesWithTypeInfo(project);
 
     final Collection<VirtualFile> mainOpenApiFiles =
@@ -105,12 +106,23 @@ public class OpenApiIndexService {
     final Project project = psiElement.getProject();
     final VirtualFile virtualFile = psiElement.getContainingFile().getVirtualFile();
 
+    return getOpenApiFileType(project, virtualFile);
+  }
+
+  public Optional<OpenApiFileType> getFileType(final CompletionParameters parameters) {
+    final Project project = parameters.getOriginalFile().getProject();
+    final VirtualFile virtualFile = parameters.getOriginalFile().getVirtualFile();
+
+    return getOpenApiFileType(project, virtualFile);
+  }
+
+  private Optional<OpenApiFileType> getOpenApiFileType(final Project project, final VirtualFile virtualFile) {
     final boolean isMainOpenApiFile = isMainOpenApiFile(virtualFile, project);
     final boolean isPartialOpenApiFile = isPartialOpenApiFile(virtualFile, project);
 
     if (isMainOpenApiFile || isPartialOpenApiFile) {
       final OpenApiFileType fileType =
-          isMainOpenApiFile ? OpenApiFileType.MAIN : getOpenApiFileType(virtualFile, project);
+              isMainOpenApiFile ? OpenApiFileType.MAIN : getPartialOpenApiFileType(virtualFile, project);
 
       return Optional.of(fileType);
     }

--- a/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
@@ -117,7 +117,7 @@ public class OpenApiIndexService {
     return getOpenApiFileType(project, virtualFile);
   }
 
-  private Optional<OpenApiFileType> getOpenApiFileType(
+  public Optional<OpenApiFileType> getOpenApiFileType(
       final Project project, final VirtualFile virtualFile) {
     final boolean isMainOpenApiFile = isMainOpenApiFile(virtualFile, project);
     final boolean isPartialOpenApiFile = isPartialOpenApiFile(virtualFile, project);

--- a/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
@@ -5,11 +5,13 @@ import static org.apache.commons.lang.StringUtils.substringBeforeLast;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.containers.HashSet;
 import com.intellij.util.indexing.FileBasedIndex;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.zalando.intellij.swagger.file.OpenApiFileType;
@@ -97,5 +99,22 @@ public class OpenApiIndexService {
         .stream()
         .flatMap(Set::stream)
         .collect(Collectors.toSet());
+  }
+
+  public Optional<OpenApiFileType> getFileType(final PsiElement psiElement) {
+    final Project project = psiElement.getProject();
+    final VirtualFile virtualFile = psiElement.getContainingFile().getVirtualFile();
+
+    final boolean isMainOpenApiFile = isMainOpenApiFile(virtualFile, project);
+    final boolean isPartialOpenApiFile = isPartialOpenApiFile(virtualFile, project);
+
+    if (isMainOpenApiFile || isPartialOpenApiFile) {
+      final OpenApiFileType fileType =
+          isMainOpenApiFile ? OpenApiFileType.MAIN : getOpenApiFileType(virtualFile, project);
+
+      return Optional.of(fileType);
+    }
+
+    return Optional.empty();
   }
 }

--- a/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
@@ -35,7 +35,8 @@ public class OpenApiIndexService {
     return partialOpenApiFiles.contains(virtualFile);
   }
 
-  private OpenApiFileType getPartialOpenApiFileType(final VirtualFile virtualFile, final Project project) {
+  private OpenApiFileType getPartialOpenApiFileType(
+      final VirtualFile virtualFile, final Project project) {
     final Set<String> partialOpenApiFilesWithTypeInfo = getPartialOpenApiFilesWithTypeInfo(project);
 
     final Collection<VirtualFile> mainOpenApiFiles =
@@ -116,13 +117,16 @@ public class OpenApiIndexService {
     return getOpenApiFileType(project, virtualFile);
   }
 
-  private Optional<OpenApiFileType> getOpenApiFileType(final Project project, final VirtualFile virtualFile) {
+  private Optional<OpenApiFileType> getOpenApiFileType(
+      final Project project, final VirtualFile virtualFile) {
     final boolean isMainOpenApiFile = isMainOpenApiFile(virtualFile, project);
     final boolean isPartialOpenApiFile = isPartialOpenApiFile(virtualFile, project);
 
     if (isMainOpenApiFile || isPartialOpenApiFile) {
       final OpenApiFileType fileType =
-              isMainOpenApiFile ? OpenApiFileType.MAIN : getPartialOpenApiFileType(virtualFile, project);
+          isMainOpenApiFile
+              ? OpenApiFileType.MAIN
+              : getPartialOpenApiFileType(virtualFile, project);
 
       return Optional.of(fileType);
     }

--- a/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerIndexService.java
@@ -34,7 +34,8 @@ public class SwaggerIndexService {
     return partialSwaggerFiles.contains(virtualFile);
   }
 
-  private SwaggerFileType getPartialSwaggerFileType(final VirtualFile virtualFile, final Project project) {
+  private SwaggerFileType getPartialSwaggerFileType(
+      final VirtualFile virtualFile, final Project project) {
     final Set<String> partialSwaggerFilesWithTypeInfo = getPartialSwaggerFilesWithTypeInfo(project);
 
     final Collection<VirtualFile> mainSwaggerFiles =
@@ -115,18 +116,20 @@ public class SwaggerIndexService {
     return getSwaggerFileType(project, virtualFile);
   }
 
-  private Optional<SwaggerFileType> getSwaggerFileType(final Project project, final VirtualFile virtualFile) {
+  private Optional<SwaggerFileType> getSwaggerFileType(
+      final Project project, final VirtualFile virtualFile) {
     final boolean isMainSwaggerFile = isMainSwaggerFile(virtualFile, project);
     final boolean isPartialSwaggerFile = isPartialSwaggerFile(virtualFile, project);
 
     if (isMainSwaggerFile || isPartialSwaggerFile) {
       final SwaggerFileType fileType =
-              isMainSwaggerFile ? SwaggerFileType.MAIN : getPartialSwaggerFileType(virtualFile, project);
+          isMainSwaggerFile
+              ? SwaggerFileType.MAIN
+              : getPartialSwaggerFileType(virtualFile, project);
 
       return Optional.of(fileType);
     }
 
     return Optional.empty();
   }
-
 }

--- a/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerIndexService.java
@@ -106,17 +106,17 @@ public class SwaggerIndexService {
     final Project project = psiElement.getProject();
     final VirtualFile virtualFile = psiElement.getContainingFile().getVirtualFile();
 
-    return getSwaggerFileType(project, virtualFile);
+    return getFileType(project, virtualFile);
   }
 
   public Optional<SwaggerFileType> getFileType(final CompletionParameters parameters) {
     final Project project = parameters.getOriginalFile().getProject();
     final VirtualFile virtualFile = parameters.getOriginalFile().getVirtualFile();
 
-    return getSwaggerFileType(project, virtualFile);
+    return getFileType(project, virtualFile);
   }
 
-  private Optional<SwaggerFileType> getSwaggerFileType(
+  public Optional<SwaggerFileType> getFileType(
       final Project project, final VirtualFile virtualFile) {
     final boolean isMainSwaggerFile = isMainSwaggerFile(virtualFile, project);
     final boolean isPartialSwaggerFile = isPartialSwaggerFile(virtualFile, project);

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/CallbacksPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/CallbacksPathResolver.java
@@ -8,4 +8,9 @@ public class CallbacksPathResolver implements PathResolver {
   public final boolean childOfCallback(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public final boolean isCallback(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/ExamplesPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/ExamplesPathResolver.java
@@ -8,4 +8,9 @@ public class ExamplesPathResolver implements PathResolver {
   public final boolean childOfExample(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public final boolean isExample(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/HeadersPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/HeadersPathResolver.java
@@ -8,4 +8,9 @@ public class HeadersPathResolver implements PathResolver {
   public final boolean childOfHeader(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public final boolean isHeader(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/LinksPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/LinksPathResolver.java
@@ -8,4 +8,9 @@ public class LinksPathResolver implements PathResolver {
   public final boolean childOfLink(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public final boolean isLink(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/MainPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/MainPathResolver.java
@@ -220,4 +220,44 @@ public class MainPathResolver implements PathResolver {
   public boolean childOfContent(PsiElement psiElement) {
     return hasPath(psiElement, "$.**.content");
   }
+
+  @Override
+  public boolean isSchema(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.schemas");
+  }
+
+  @Override
+  public boolean isResponse(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.responses");
+  }
+
+  @Override
+  public boolean isParameter(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.parameters");
+  }
+
+  @Override
+  public boolean isExample(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.examples");
+  }
+
+  @Override
+  public boolean isRequestBody(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.requestBodies");
+  }
+
+  @Override
+  public boolean isHeader(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.headers");
+  }
+
+  @Override
+  public boolean isLink(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.links");
+  }
+
+  @Override
+  public boolean isCallback(PsiElement psiElement) {
+    return hasPath(psiElement, "$.components.callbacks");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/ParametersPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/ParametersPathResolver.java
@@ -8,4 +8,9 @@ public class ParametersPathResolver implements PathResolver {
   public final boolean childOfParameters(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public final boolean isParameter(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/PathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/PathResolver.java
@@ -161,6 +161,38 @@ public interface PathResolver {
     return false;
   }
 
+  default boolean isSchema(PsiElement psiElement) {
+    return false;
+  }
+
+  default boolean isResponse(PsiElement psiElement) {
+    return false;
+  }
+
+  default boolean isParameter(PsiElement psiElement) {
+    return false;
+  }
+
+  default boolean isExample(PsiElement psiElement) {
+    return false;
+  }
+
+  default boolean isRequestBody(PsiElement psiElement) {
+    return false;
+  }
+
+  default boolean isHeader(PsiElement psiElement) {
+    return false;
+  }
+
+  default boolean isLink(PsiElement psiElement) {
+    return false;
+  }
+
+  default boolean isCallback(PsiElement psiElement) {
+    return false;
+  }
+
   default boolean hasPath(final PsiElement psiElement, final String pathExpression) {
     return new PathFinder().isInsidePath(psiElement, pathExpression);
   }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/RequestBodiesPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/RequestBodiesPathResolver.java
@@ -8,4 +8,9 @@ public class RequestBodiesPathResolver implements PathResolver {
   public final boolean childOfRequestBody(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public final boolean isRequestBody(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/ResponsesPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/ResponsesPathResolver.java
@@ -8,4 +8,9 @@ public class ResponsesPathResolver implements PathResolver {
   public final boolean childOfResponse(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public final boolean isResponse(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/SchemasPathResolver.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/openapi/SchemasPathResolver.java
@@ -8,4 +8,9 @@ public class SchemasPathResolver implements PathResolver {
   public final boolean childOfSchema(final PsiElement psiElement) {
     return hasPath(psiElement, "$.*");
   }
+
+  @Override
+  public boolean isSchema(final PsiElement psiElement) {
+    return hasPath(psiElement, "$");
+  }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -42,6 +42,9 @@
         <annotator language="JSON" implementationClass="org.zalando.intellij.swagger.annotator.swagger.JsonUnusedRefAnnotator"/>
         <annotator language="yaml" implementationClass="org.zalando.intellij.swagger.annotator.swagger.YamlUnusedRefAnnotator"/>
 
+        <annotator language="JSON" implementationClass="org.zalando.intellij.swagger.annotator.openapi.JsonUnusedRefAnnotator"/>
+        <annotator language="yaml" implementationClass="org.zalando.intellij.swagger.annotator.openapi.YamlUnusedRefAnnotator"/>
+
         <fileDocumentManagerListener implementation="org.zalando.intellij.swagger.ui.provider.FileDocumentListener"/>
         <webBrowserUrlProvider implementation="org.zalando.intellij.swagger.ui.provider.SwaggerUiUrlProvider" order="last"/>
 

--- a/src/test/java/org/zalando/intellij/swagger/validator/openapi/json/UnusedRefTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/openapi/json/UnusedRefTest.java
@@ -1,0 +1,43 @@
+package org.zalando.intellij.swagger.validator.openapi.json;
+
+import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
+
+public class UnusedRefTest extends SwaggerLightCodeInsightFixtureTestCase {
+
+  private void doTest(final String fileName) {
+    myFixture.testHighlighting(
+        true, false, true, "validator/field/openapi/unused/json/" + fileName);
+  }
+
+  public void testUnusedSchemaMainFile() {
+    doTest("unused_schema_main_file.json");
+  }
+
+  public void testUnusedCallbackMainFile() {
+    doTest("unused_callback_main_file.json");
+  }
+
+  public void testUnusedExampleMainFile() {
+    doTest("unused_example_main_file.json");
+  }
+
+  public void testUnusedHeaderMainFile() {
+    doTest("unused_header_main_file.json");
+  }
+
+  public void testUnusedLinkMainFile() {
+    doTest("unused_link_main_file.json");
+  }
+
+  public void testUnusedParameterMainFile() {
+    doTest("unused_parameter_main_file.json");
+  }
+
+  public void testUnusedRequestBodyMainFile() {
+    doTest("unused_request_body_main_file.json");
+  }
+
+  public void testUnusedResponseMainFile() {
+    doTest("unused_response_main_file.json");
+  }
+}

--- a/src/test/java/org/zalando/intellij/swagger/validator/openapi/yaml/UnusedRefTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/openapi/yaml/UnusedRefTest.java
@@ -1,0 +1,42 @@
+package org.zalando.intellij.swagger.validator.openapi.yaml;
+
+import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
+
+public class UnusedRefTest extends SwaggerLightCodeInsightFixtureTestCase {
+
+  private void doTest(final String fileName) {
+    myFixture.testHighlighting(true, false, true, "validator/field/openapi/" + fileName);
+  }
+
+  public void testUnusedSchemaMainFile() {
+    doTest("unused/yaml/unused_schema_main_file.yaml");
+  }
+
+  public void testUnusedCallbackMainFile() {
+    doTest("unused/yaml/unused_callback_main_file.yaml");
+  }
+
+  public void testUnusedExampleMainFile() {
+    doTest("unused/yaml/unused_example_main_file.yaml");
+  }
+
+  public void testUnusedHeaderMainFile() {
+    doTest("unused/yaml/unused_header_main_file.yaml");
+  }
+
+  public void testUnusedLinkMainFile() {
+    doTest("unused/yaml/unused_link_main_file.yaml");
+  }
+
+  public void testUnusedParameterMainFile() {
+    doTest("unused/yaml/unused_parameter_main_file.yaml");
+  }
+
+  public void testUnusedRequestBodyMainFile() {
+    doTest("unused/yaml/unused_request_body_main_file.yaml");
+  }
+
+  public void testUnusedResponseMainFile() {
+    doTest("unused/yaml/unused_response_main_file.yaml");
+  }
+}

--- a/src/test/java/org/zalando/intellij/swagger/validator/swagger/UnknownFieldTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/swagger/UnknownFieldTest.java
@@ -1,4 +1,4 @@
-package org.zalando.intellij.swagger.validator;
+package org.zalando.intellij.swagger.validator.swagger;
 
 import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
 

--- a/src/test/java/org/zalando/intellij/swagger/validator/swagger/UnknownValueTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/swagger/UnknownValueTest.java
@@ -1,4 +1,4 @@
-package org.zalando.intellij.swagger.validator;
+package org.zalando.intellij.swagger.validator.swagger;
 
 import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
 

--- a/src/test/java/org/zalando/intellij/swagger/validator/swagger/ValidFileTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/swagger/ValidFileTest.java
@@ -1,4 +1,4 @@
-package org.zalando.intellij.swagger.validator;
+package org.zalando.intellij.swagger.validator.swagger;
 
 import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
 

--- a/src/test/java/org/zalando/intellij/swagger/validator/swagger/json/UnusedRefTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/swagger/json/UnusedRefTest.java
@@ -1,4 +1,4 @@
-package org.zalando.intellij.swagger.validator.json;
+package org.zalando.intellij.swagger.validator.swagger.json;
 
 import com.intellij.openapi.vfs.VirtualFile;
 import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;

--- a/src/test/java/org/zalando/intellij/swagger/validator/swagger/yaml/UnusedRefTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/validator/swagger/yaml/UnusedRefTest.java
@@ -1,4 +1,4 @@
-package org.zalando.intellij.swagger.validator.yaml;
+package org.zalando.intellij.swagger.validator.swagger.yaml;
 
 import com.intellij.openapi.vfs.VirtualFile;
 import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_callback_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_callback_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "callbacks": {
+      <weak_warning descr="Callback is never used">"Callback1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_example_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_example_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "examples": {
+      <weak_warning descr="Example is never used">"Example1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_header_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_header_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "headers": {
+      <weak_warning descr="Header is never used">"Header1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_link_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_link_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "links": {
+      <weak_warning descr="Link is never used">"Link1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_parameter_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_parameter_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "parameters": {
+      <weak_warning descr="Parameter is never used">"Parameter1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_request_body_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_request_body_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "requestBodies": {
+      <weak_warning descr="Request body is never used">"RequestBody1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_response_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_response_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "responses": {
+      <weak_warning descr="Response is never used">"Response1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/json/unused_schema_main_file.json
+++ b/src/test/resources/testing/validator/field/openapi/unused/json/unused_schema_main_file.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      <weak_warning descr="Schema is never used">"Schema1"</weak_warning>:{}
+    }
+  }
+}

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_callback_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_callback_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  callbacks:
+    <weak_warning descr="Callback is never used">Callback1:</weak_warning>

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_example_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_example_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  examples:
+    <weak_warning descr="Example is never used">Example1:</weak_warning>

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_header_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_header_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  headers:
+    <weak_warning descr="Header is never used">Header1:</weak_warning>

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_link_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_link_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  links:
+    <weak_warning descr="Link is never used">Link1:</weak_warning>

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_parameter_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_parameter_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  parameters:
+    <weak_warning descr="Parameter is never used">Parameter1:</weak_warning>

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_request_body_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_request_body_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  requestBodies:
+    <weak_warning descr="Request body is never used">RequestBody1:</weak_warning>

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_response_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_response_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  responses:
+    <weak_warning descr="Response is never used">Response1:</weak_warning>

--- a/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_schema_main_file.yaml
+++ b/src/test/resources/testing/validator/field/openapi/unused/yaml/unused_schema_main_file.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+components:
+  schemas:
+    <weak_warning descr="Schema is never used">Schema1:</weak_warning>


### PR DESCRIPTION
This commit introduces a new annotator for displaying a warning for components that are not referenced by any element.

Fixes #221

Example:

![image](https://user-images.githubusercontent.com/1151536/49735103-ed348d80-fc8e-11e8-8623-c860c7404279.png)

