### PR TITLE
Swagger UI file references support

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/index/IndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/IndexService.java
@@ -1,0 +1,32 @@
+package org.zalando.intellij.swagger.index;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
+import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
+
+import java.util.Optional;
+
+public class IndexService {
+
+  private final OpenApiIndexService openApiIndexService = new OpenApiIndexService();
+  private final SwaggerIndexService swaggerIndexService = new SwaggerIndexService();
+
+  public Optional<VirtualFile> getMainSpecFile(final PsiFile psiFile) {
+
+    final VirtualFile virtualFile = psiFile.getVirtualFile();
+    final Project project = psiFile.getProject();
+
+    if (openApiIndexService.isMainOpenApiFile(virtualFile, project)
+        || swaggerIndexService.isMainSwaggerFile(virtualFile, project)) {
+      return Optional.of(psiFile.getVirtualFile());
+    } else if (openApiIndexService.isPartialOpenApiFile(virtualFile, project)) {
+      return openApiIndexService.getMainOpenApiFile(project);
+    } else if (swaggerIndexService.isPartialSwaggerFile(virtualFile, project)) {
+      return swaggerIndexService.getMainSwaggerFile(project);
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/index/IndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/IndexService.java
@@ -3,10 +3,9 @@ package org.zalando.intellij.swagger.index;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import java.util.Optional;
 import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
 import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
-
-import java.util.Optional;
 
 public class IndexService {
 

--- a/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiIndexService.java
@@ -9,7 +9,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.indexing.FileBasedIndex;
-
 import java.util.*;
 import java.util.stream.Collectors;
 import org.zalando.intellij.swagger.file.OpenApiFileType;
@@ -49,7 +48,8 @@ public class OpenApiIndexService {
 
     final VirtualFile mainOpenApiFileFolder = mainOpenApiFiles.iterator().next().getParent();
 
-    return partialOpenApiFilesWithTypeInfo.stream()
+    return partialOpenApiFilesWithTypeInfo
+        .stream()
         .filter(
             nameWithTypeInfo -> {
               final VirtualFile foundFile =
@@ -72,7 +72,8 @@ public class OpenApiIndexService {
     return mainOpenApiFolder
         .map(
             specFolder ->
-                partialOpenApiFilesWithTypeInfo.stream()
+                partialOpenApiFilesWithTypeInfo
+                    .stream()
                     .map(v -> substringBeforeLast(v, OpenApiDataIndexer.DELIMITER))
                     .map(specFolder::findFileByRelativePath)
                     .filter(Objects::nonNull)

--- a/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerIndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerIndexService.java
@@ -8,9 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.util.containers.HashSet;
 import com.intellij.util.indexing.FileBasedIndex;
-
 import java.util.*;
 import java.util.stream.Collectors;
 import org.zalando.intellij.swagger.file.SwaggerFileType;
@@ -49,7 +47,8 @@ public class SwaggerIndexService {
 
     final VirtualFile mainSwaggerFileFolder = mainSwaggerFiles.iterator().next().getParent();
 
-    return partialSwaggerFilesWithTypeInfo.stream()
+    return partialSwaggerFilesWithTypeInfo
+        .stream()
         .filter(
             nameWithTypeInfo -> {
               final VirtualFile foundFile =
@@ -87,7 +86,8 @@ public class SwaggerIndexService {
     return mainSwaggerFolder
         .map(
             specFolder ->
-                partialSwaggerFilesWithTypeInfo.stream()
+                partialSwaggerFilesWithTypeInfo
+                    .stream()
                     .map(v -> substringBeforeLast(v, SwaggerDataIndexer.DELIMITER))
                     .map(specFolder::findFileByRelativePath)
                     .filter(Objects::nonNull)

--- a/src/main/java/org/zalando/intellij/swagger/service/JsonBuilderService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/JsonBuilderService.java
@@ -1,0 +1,110 @@
+package org.zalando.intellij.swagger.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.RecursionGuard;
+import com.intellij.openapi.util.RecursionManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+class JsonBuilderService {
+
+  private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+  /*
+   * We need to use a recursion guard because of circular references;
+   * traversing them would result in a stack overflow.
+   */
+  private static final RecursionGuard recursionGuard =
+      RecursionManager.createGuard("JsonBuilderService.buildWithResolvedReferences");
+
+  /*
+   * It is safe to use a cache for already resolved references.
+   */
+  private static final boolean memoize = true;
+
+  JsonNode buildWithResolvedReferences(final JsonNode root, final VirtualFile containingFile) {
+
+    if (root.isObject()) {
+
+      Iterator<Map.Entry<String, JsonNode>> iterator = root.fields();
+
+      while (iterator.hasNext()) {
+        Map.Entry<String, JsonNode> current = iterator.next();
+
+        final JsonNode ref = current.getValue().get("$ref");
+
+        if (ref != null && ref.isTextual()) {
+          final String text = ref.asText();
+          if (isFileReference(text)) {
+            final Pair<JsonNode, VirtualFile> referencedNode = refToJsonNode(text, containingFile);
+
+            if (referencedNode != null && !referencedNode.first.isMissingNode()) {
+              final JsonNode resolvedValue =
+                  recursionGuard.doPreventingRecursion(
+                      referencedNode,
+                      memoize,
+                      () ->
+                          buildWithResolvedReferences(referencedNode.first, referencedNode.second));
+
+              if (resolvedValue != null) {
+                ((ObjectNode) root).replace(current.getKey(), resolvedValue);
+              } else {
+                ((ObjectNode) root)
+                    .replace(
+                        current.getKey(),
+                        mapper.createObjectNode().put("$ref", "Circular reference!"));
+              }
+            }
+          }
+        } else {
+          buildWithResolvedReferences(current.getValue(), containingFile);
+        }
+      }
+    }
+
+    return root;
+  }
+
+  private boolean isFileReference(final String text) {
+    return text.endsWith(".json")
+        || text.contains(".json#/")
+        || text.endsWith(".yaml")
+        || text.contains(".yaml#/")
+        || text.endsWith(".yml")
+        || text.contains(".yml#/");
+  }
+
+  private Pair<JsonNode, VirtualFile> refToJsonNode(
+      final String ref, final VirtualFile containingFile) {
+
+    final VirtualFile virtualFile = getVirtualFile(ref, containingFile);
+
+    if (virtualFile == null) return null;
+
+    final JsonNode tree;
+    try {
+      tree = mapper.readTree(new File(virtualFile.getPath()));
+    } catch (IOException e) {
+      return null;
+    }
+
+    final String s = StringUtils.substringAfter(ref, "#");
+
+    return Pair.create(tree.at(s), virtualFile);
+  }
+
+  private VirtualFile getVirtualFile(final String ref, final VirtualFile containingFile) {
+    final String relativePath = StringUtils.substringBefore(ref, "#");
+
+    return containingFile.getParent().findFileByRelativePath(relativePath);
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/service/JsonBuilderService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/JsonBuilderService.java
@@ -8,12 +8,11 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.RecursionGuard;
 import com.intellij.openapi.util.RecursionManager;
 import com.intellij.openapi.vfs.VirtualFile;
-import org.apache.commons.lang.StringUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 
 class JsonBuilderService {
 

--- a/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
@@ -10,16 +10,15 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.impl.LoadTextUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.LocalFileUrl;
-import org.jetbrains.annotations.NotNull;
-import org.zalando.intellij.swagger.file.FileContentManipulator;
-import org.zalando.intellij.swagger.file.SwaggerUiCreator;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.intellij.swagger.file.FileContentManipulator;
+import org.zalando.intellij.swagger.file.SwaggerUiCreator;
 
 public class SwaggerFileService {
 
@@ -47,7 +46,8 @@ public class SwaggerFileService {
                 .runReadAction(
                     () -> {
                       try {
-                        convertSwaggerToHtmlWithCache(virtualFile, convertToJsonIfNecessary(virtualFile));
+                        convertSwaggerToHtmlWithCache(
+                            virtualFile, convertToJsonIfNecessary(virtualFile));
                       } catch (Exception e) {
                         // This is a no-op; we don't want to notify the user if the
                         // Swagger UI generation fails on file save. A user may

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
@@ -5,15 +5,18 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
-import org.zalando.intellij.swagger.file.FileDetector;
+import org.zalando.intellij.swagger.index.IndexService;
 import org.zalando.intellij.swagger.service.SwaggerFileService;
+
+import java.util.Optional;
 
 public class FileDocumentListener extends FileDocumentManagerAdapter {
 
-  private final FileDetector fileDetector = new FileDetector();
+  private final IndexService indexService = new IndexService();
 
   @Override
   public void beforeDocumentSaving(@NotNull final Document document) {
@@ -24,12 +27,9 @@ public class FileDocumentListener extends FileDocumentManagerAdapter {
       final PsiFile psiFile = PsiDocumentManager.getInstance(openProjects[0]).getPsiFile(document);
 
       if (psiFile != null) {
-        final boolean swaggerFile =
-            fileDetector.isMainSwaggerFile(psiFile) || fileDetector.isMainOpenApiFile(psiFile);
+        final Optional<VirtualFile> specFile = indexService.getMainSpecFile(psiFile);
 
-        if (swaggerFile) {
-          swaggerFileService.convertSwaggerToHtmlAsync(psiFile);
-        }
+        specFile.ifPresent(swaggerFileService::convertSwaggerToHtmlAsync);
       }
     }
   }

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
@@ -8,11 +8,10 @@ import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.index.IndexService;
 import org.zalando.intellij.swagger.service.SwaggerFileService;
-
-import java.util.Optional;
 
 public class FileDocumentListener extends FileDocumentManagerAdapter {
 

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
@@ -29,7 +29,8 @@ public class SwaggerUiUrlProvider extends BuiltInWebBrowserUrlProvider implement
   @Override
   protected Url getUrl(@NotNull OpenInBrowserRequest request, @NotNull VirtualFile file) {
     SwaggerFileService swaggerFileService = ServiceManager.getService(SwaggerFileService.class);
-    Optional<Path> swaggerHTMLFolder = swaggerFileService.convertSwaggerToHtml(request.getVirtualFile());
+    Optional<Path> swaggerHTMLFolder =
+        swaggerFileService.convertSwaggerToHtml(request.getVirtualFile());
 
     return swaggerHTMLFolder.map(SwaggerFilesUtils::convertSwaggerLocationToUrl).orElse(null);
   }

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
@@ -29,7 +29,7 @@ public class SwaggerUiUrlProvider extends BuiltInWebBrowserUrlProvider implement
   @Override
   protected Url getUrl(@NotNull OpenInBrowserRequest request, @NotNull VirtualFile file) {
     SwaggerFileService swaggerFileService = ServiceManager.getService(SwaggerFileService.class);
-    Optional<Path> swaggerHTMLFolder = swaggerFileService.convertSwaggerToHtml(request.getFile());
+    Optional<Path> swaggerHTMLFolder = swaggerFileService.convertSwaggerToHtml(request.getVirtualFile());
 
     return swaggerHTMLFolder.map(SwaggerFilesUtils::convertSwaggerLocationToUrl).orElse(null);
   }

--- a/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
@@ -1,0 +1,243 @@
+package org.zalando.intellij.swagger.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class JsonBuilderTest {
+
+  private final JsonBuilderService jsonBuilderService = new JsonBuilderService();
+
+  private VirtualFile fakeVirtualFile = mock(VirtualFile.class);
+  private VirtualFile fakeVirtualFile2 = mock(VirtualFile.class);
+  private VirtualFile fakeVirtualFile3 = mock(VirtualFile.class);
+
+  @Before
+  public void before() {
+    when(fakeVirtualFile.getParent()).thenReturn(fakeVirtualFile);
+    when(fakeVirtualFile2.getParent()).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile3.getParent()).thenReturn(fakeVirtualFile3);
+  }
+
+  @Test
+  public void thatFileWithoutFileReferencesIsHandled() {
+    final JsonNode jsonNode = getJsonNode("petstore.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatFileWithDepthOneReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath(anyString())).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error.json").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_1.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_1_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatFileWithDepthTwoReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_2.json")).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_2.json").getPath());
+
+    when(fakeVirtualFile2.findFileByRelativePath("Error.json")).thenReturn(fakeVirtualFile3);
+    when(fakeVirtualFile3.getPath()).thenReturn(getUrl("partial/Error.json").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_2.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_2_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatMissingFileReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error.json")).thenReturn(null);
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_3.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_3_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatMissingJsonElementReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath(anyString())).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error.json").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_4.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_4_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatJsonElementReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath(anyString())).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_5.json").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_6.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_6_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatCircularReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_3.json")).thenReturn(fakeVirtualFile2);
+
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_3.json").getPath());
+    when(fakeVirtualFile2.findFileByRelativePath("Error_4.json")).thenReturn(fakeVirtualFile3);
+
+    when(fakeVirtualFile3.getPath()).thenReturn(getUrl("partial/Error_4.json").getPath());
+    when(fakeVirtualFile3.findFileByRelativePath("Error_3.json")).thenReturn(fakeVirtualFile2);
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_5.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_5_after.json");
+
+    assertEquals(expected, result);
+
+  }
+
+  @Test
+  public void thatYamlFileWithDepthOneReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath(anyString())).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error.yaml").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_1.yaml");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_1_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatYamlFileWithDepthTwoReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_2.yaml")).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_2.yaml").getPath());
+
+    when(fakeVirtualFile2.findFileByRelativePath("Error.yaml")).thenReturn(fakeVirtualFile3);
+    when(fakeVirtualFile3.getPath()).thenReturn(getUrl("partial/Error.yaml").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_2.yaml");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_2_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatMissingYamlFileReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error.yaml")).thenReturn(null);
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_3.yaml");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_3_yaml_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatMissingYamlElementReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath(anyString())).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error.yaml").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_4.yaml");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_4_yaml_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatYamlElementReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath(anyString())).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_5.yaml").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_6.yaml");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_6_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatCircularYamlReferenceIsHandled() {
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_3.yaml")).thenReturn(fakeVirtualFile2);
+
+    when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_3.yaml").getPath());
+    when(fakeVirtualFile2.findFileByRelativePath("Error_4.yaml")).thenReturn(fakeVirtualFile3);
+
+    when(fakeVirtualFile3.getPath()).thenReturn(getUrl("partial/Error_4.yaml").getPath());
+    when(fakeVirtualFile3.findFileByRelativePath("Error_3.yaml")).thenReturn(fakeVirtualFile2);
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_5.yaml");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_5_after.json");
+
+    assertEquals(expected, result);
+
+  }
+
+  private JsonNode getJsonNode(final String fileName) {
+    try {
+      final URL url = getUrl(fileName);
+      final File file = new File(url.toURI());
+
+      final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+      return mapper.readTree(file);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private URL getUrl(final String fileName) {
+    return ClassLoader.getSystemClassLoader().getResource("service/json/" + fileName);
+  }
+}

--- a/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
@@ -1,18 +1,16 @@
 package org.zalando.intellij.swagger.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.intellij.openapi.vfs.VirtualFile;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.io.File;
 import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
 
 public class JsonBuilderTest {
 
@@ -56,7 +54,8 @@ public class JsonBuilderTest {
 
   @Test
   public void thatFileWithDepthTwoReferenceIsHandled() {
-    when(fakeVirtualFile.findFileByRelativePath("partial/Error_2.json")).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_2.json"))
+        .thenReturn(fakeVirtualFile2);
     when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_2.json").getPath());
 
     when(fakeVirtualFile2.findFileByRelativePath("Error.json")).thenReturn(fakeVirtualFile3);
@@ -114,7 +113,8 @@ public class JsonBuilderTest {
 
   @Test
   public void thatCircularReferenceIsHandled() {
-    when(fakeVirtualFile.findFileByRelativePath("partial/Error_3.json")).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_3.json"))
+        .thenReturn(fakeVirtualFile2);
 
     when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_3.json").getPath());
     when(fakeVirtualFile2.findFileByRelativePath("Error_4.json")).thenReturn(fakeVirtualFile3);
@@ -129,7 +129,6 @@ public class JsonBuilderTest {
     JsonNode expected = getJsonNode("petstore_with_file_ref_5_after.json");
 
     assertEquals(expected, result);
-
   }
 
   @Test
@@ -148,7 +147,8 @@ public class JsonBuilderTest {
 
   @Test
   public void thatYamlFileWithDepthTwoReferenceIsHandled() {
-    when(fakeVirtualFile.findFileByRelativePath("partial/Error_2.yaml")).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_2.yaml"))
+        .thenReturn(fakeVirtualFile2);
     when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_2.yaml").getPath());
 
     when(fakeVirtualFile2.findFileByRelativePath("Error.yaml")).thenReturn(fakeVirtualFile3);
@@ -206,7 +206,8 @@ public class JsonBuilderTest {
 
   @Test
   public void thatCircularYamlReferenceIsHandled() {
-    when(fakeVirtualFile.findFileByRelativePath("partial/Error_3.yaml")).thenReturn(fakeVirtualFile2);
+    when(fakeVirtualFile.findFileByRelativePath("partial/Error_3.yaml"))
+        .thenReturn(fakeVirtualFile2);
 
     when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error_3.yaml").getPath());
     when(fakeVirtualFile2.findFileByRelativePath("Error_4.yaml")).thenReturn(fakeVirtualFile3);
@@ -221,7 +222,6 @@ public class JsonBuilderTest {
     JsonNode expected = getJsonNode("petstore_with_file_ref_5_after.json");
 
     assertEquals(expected, result);
-
   }
 
   private JsonNode getJsonNode(final String fileName) {

--- a/src/test/resources/service/json/partial/Error.json
+++ b/src/test/resources/service/json/partial/Error.json
@@ -1,0 +1,15 @@
+{
+  "required": [
+    "code",
+    "message"
+  ],
+  "properties": {
+    "code": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "message": {
+      "type": "string"
+    }
+  }
+}

--- a/src/test/resources/service/json/partial/Error.yaml
+++ b/src/test/resources/service/json/partial/Error.yaml
@@ -1,0 +1,9 @@
+required:
+  - code
+  - message
+properties:
+  code:
+    type: integer
+    format: int32
+  message:
+    type: string

--- a/src/test/resources/service/json/partial/Error_2.json
+++ b/src/test/resources/service/json/partial/Error_2.json
@@ -1,0 +1,10 @@
+{
+  "properties": {
+    "prop1": {
+      "type": "array",
+      "items": {
+        "$ref": "Error.json"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/partial/Error_2.yaml
+++ b/src/test/resources/service/json/partial/Error_2.yaml
@@ -1,0 +1,5 @@
+properties:
+  prop1:
+    type: array
+    items:
+      "$ref": Error.yaml

--- a/src/test/resources/service/json/partial/Error_3.json
+++ b/src/test/resources/service/json/partial/Error_3.json
@@ -1,0 +1,10 @@
+{
+  "properties": {
+    "prop1": {
+      "type": "array",
+      "items": {
+        "$ref": "Error_4.json"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/partial/Error_3.yaml
+++ b/src/test/resources/service/json/partial/Error_3.yaml
@@ -1,0 +1,5 @@
+properties:
+  prop1:
+    type: array
+    items:
+      "$ref": Error_4.yaml

--- a/src/test/resources/service/json/partial/Error_4.json
+++ b/src/test/resources/service/json/partial/Error_4.json
@@ -1,0 +1,10 @@
+{
+  "properties": {
+    "prop1": {
+      "type": "array",
+      "items": {
+        "$ref": "Error_3.json"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/partial/Error_4.yaml
+++ b/src/test/resources/service/json/partial/Error_4.yaml
@@ -1,0 +1,5 @@
+properties:
+  prop1:
+    type: array
+    items:
+      "$ref": Error_3.yaml

--- a/src/test/resources/service/json/partial/Error_5.json
+++ b/src/test/resources/service/json/partial/Error_5.json
@@ -1,0 +1,17 @@
+{
+  "Error": {
+    "required": [
+      "code",
+      "message"
+    ],
+    "properties": {
+      "code": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "message": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/partial/Error_5.yaml
+++ b/src/test/resources/service/json/partial/Error_5.yaml
@@ -1,0 +1,10 @@
+Error:
+  required:
+    - code
+    - message
+  properties:
+    code:
+      type: integer
+      format: int32
+    message:
+      type: string

--- a/src/test/resources/service/json/petstore.json
+++ b/src/test/resources/service/json/petstore.json
@@ -1,0 +1,153 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_after.json
+++ b/src/test/resources/service/json/petstore_after.json
@@ -1,0 +1,153 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_1.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_1.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_1.yaml
+++ b/src/test/resources/service/json/petstore_with_file_ref_1.yaml
@@ -1,0 +1,91 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: "/v1"
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      "$ref": "#/definitions/Pet"

--- a/src/test/resources/service/json/petstore_with_file_ref_1_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_1_after.json
@@ -1,0 +1,174 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_2.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_2.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_2.json"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_2.json"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_2.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_2.yaml
+++ b/src/test/resources/service/json/petstore_with_file_ref_2.yaml
@@ -1,0 +1,91 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: "/v1"
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_2.yaml
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_2.yaml
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_2.yaml
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      "$ref": "#/definitions/Pet"

--- a/src/test/resources/service/json/petstore_with_file_ref_2_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_2_after.json
@@ -1,0 +1,195 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "properties": {
+                "prop1": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "code",
+                      "message"
+                    ],
+                    "properties": {
+                      "code": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "properties": {
+                "prop1": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "code",
+                      "message"
+                    ],
+                    "properties": {
+                      "code": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "properties": {
+                "prop1": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "code",
+                      "message"
+                    ],
+                    "properties": {
+                      "code": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_3.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_3.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_3.yaml
+++ b/src/test/resources/service/json/petstore_with_file_ref_3.yaml
@@ -1,0 +1,92 @@
+---
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: "/v1"
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      "$ref": "#/definitions/Pet"

--- a/src/test/resources/service/json/petstore_with_file_ref_3_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_3_after.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_3_yaml_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_3_yaml_after.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.yaml"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.yaml"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.yaml"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_4.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_4.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json#/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json#/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json#/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_4.yaml
+++ b/src/test/resources/service/json/petstore_with_file_ref_4.yaml
@@ -1,0 +1,91 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: "/v1"
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml#/Error
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml#/Error
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error.yaml#/Error
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      "$ref": "#/definitions/Pet"

--- a/src/test/resources/service/json/petstore_with_file_ref_4_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_4_after.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json#/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json#/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.json#/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_4_yaml_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_4_yaml_after.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.yaml#/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.yaml#/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error.yaml#/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_5.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_5.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_3.json"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_3.json"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_3.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_5.yaml
+++ b/src/test/resources/service/json/petstore_with_file_ref_5.yaml
@@ -1,0 +1,91 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: "/v1"
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_3.yaml
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_3.yaml
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_3.yaml
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      "$ref": "#/definitions/Pet"

--- a/src/test/resources/service/json/petstore_with_file_ref_5_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_5_after.json
@@ -1,0 +1,180 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "properties": {
+                "prop1": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "prop1": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "Circular reference!"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "properties": {
+                "prop1": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "prop1": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "Circular reference!"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "properties": {
+                "prop1": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "prop1": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "Circular reference!"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_6.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_6.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_5.json#/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_5.json#/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "partial/Error_5.json#/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_6.yaml
+++ b/src/test/resources/service/json/petstore_with_file_ref_6.yaml
@@ -1,0 +1,91 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: "/v1"
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_5.yaml#/Error
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_5.yaml#/Error
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            "$ref": "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            "$ref": partial/Error_5.yaml#/Error
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      "$ref": "#/definitions/Pet"

--- a/src/test/resources/service/json/petstore_with_file_ref_6_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_6_after.json
@@ -1,0 +1,174 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit improves the Swagger UI in case of file references.
It traverses the JSON tree recursively and tries to resolve
references. Once resolved, the original $ref key is replaced
by the resolved content.

Fixes #184