### PR TITLE
Fixes IllegalStateException in JSON exclusion

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/SwaggerJsonCatalogExclusion.java
+++ b/src/main/java/org/zalando/intellij/swagger/SwaggerJsonCatalogExclusion.java
@@ -3,26 +3,23 @@ package org.zalando.intellij.swagger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiManager;
 import com.jetbrains.jsonSchema.remote.JsonSchemaCatalogExclusion;
 import org.jetbrains.annotations.NotNull;
-import org.zalando.intellij.swagger.file.FileDetector;
+import org.zalando.intellij.swagger.index.IndexService;
+import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
+import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
 
 public class SwaggerJsonCatalogExclusion implements JsonSchemaCatalogExclusion {
 
-  private final FileDetector fileDetector = new FileDetector();
+  private final IndexService indexService =
+      new IndexService(new OpenApiIndexService(), new SwaggerIndexService());
 
   @Override
   public boolean isExcluded(@NotNull VirtualFile file) {
     final Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
 
     if (openProjects.length > 0) {
-      final PsiFile psiFile = PsiManager.getInstance(openProjects[0]).findFile(file);
-
-      if (psiFile != null) {
-        return fileDetector.isMainSwaggerFile(psiFile) || fileDetector.isMainOpenApiFile(psiFile);
-      }
+      return indexService.isMainSpecFile(file, openProjects[0]);
     }
 
     return false;

--- a/src/main/java/org/zalando/intellij/swagger/index/IndexService.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/IndexService.java
@@ -9,16 +9,26 @@ import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
 
 public class IndexService {
 
-  private final OpenApiIndexService openApiIndexService = new OpenApiIndexService();
-  private final SwaggerIndexService swaggerIndexService = new SwaggerIndexService();
+  private final OpenApiIndexService openApiIndexService;
+  private final SwaggerIndexService swaggerIndexService;
+
+  public IndexService() {
+    this(new OpenApiIndexService(), new SwaggerIndexService());
+  }
+
+  public IndexService(
+      final OpenApiIndexService openApiIndexService,
+      final SwaggerIndexService swaggerIndexService) {
+    this.openApiIndexService = openApiIndexService;
+    this.swaggerIndexService = swaggerIndexService;
+  }
 
   public Optional<VirtualFile> getMainSpecFile(final PsiFile psiFile) {
 
     final VirtualFile virtualFile = psiFile.getVirtualFile();
     final Project project = psiFile.getProject();
 
-    if (openApiIndexService.isMainOpenApiFile(virtualFile, project)
-        || swaggerIndexService.isMainSwaggerFile(virtualFile, project)) {
+    if (isMainSpecFile(virtualFile, project)) {
       return Optional.of(psiFile.getVirtualFile());
     } else if (openApiIndexService.isPartialOpenApiFile(virtualFile, project)) {
       return openApiIndexService.getMainOpenApiFile(project);
@@ -27,5 +37,10 @@ public class IndexService {
     } else {
       return Optional.empty();
     }
+  }
+
+  public boolean isMainSpecFile(final VirtualFile virtualFile, final Project project) {
+    return openApiIndexService.isMainOpenApiFile(virtualFile, project)
+        || swaggerIndexService.isMainSwaggerFile(virtualFile, project);
   }
 }

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
@@ -11,11 +11,14 @@ import com.intellij.psi.PsiFile;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.index.IndexService;
+import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
+import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
 import org.zalando.intellij.swagger.service.SwaggerFileService;
 
 public class FileDocumentListener extends FileDocumentManagerAdapter {
 
-  private final IndexService indexService = new IndexService();
+  private final IndexService indexService =
+      new IndexService(new OpenApiIndexService(), new SwaggerIndexService());
 
   @Override
   public void beforeDocumentSaving(@NotNull final Document document) {

--- a/src/test/java/org/zalando/intellij/swagger/index/IndexServiceTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/index/IndexServiceTest.java
@@ -1,0 +1,51 @@
+package org.zalando.intellij.swagger.index;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.junit.Test;
+import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
+import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
+
+public class IndexServiceTest {
+
+  private final OpenApiIndexService fakeOpenApiIndexService = mock(OpenApiIndexService.class);
+  private final SwaggerIndexService fakeSwaggerIndexService = mock(SwaggerIndexService.class);
+
+  private final IndexService indexService =
+      new IndexService(fakeOpenApiIndexService, fakeSwaggerIndexService);
+
+  private final VirtualFile fakeVirtualFile = mock(VirtualFile.class);
+  private final Project fakeProject = mock(Project.class);
+
+  @Test
+  public void thatMainSwaggerFileIsDetected() {
+    when(fakeSwaggerIndexService.isMainSwaggerFile(fakeVirtualFile, fakeProject)).thenReturn(true);
+
+    final boolean isMainSpec = indexService.isMainSpecFile(fakeVirtualFile, fakeProject);
+
+    assertThat(isMainSpec, is(true));
+  }
+
+  @Test
+  public void thatMainOpenApiFileIsDetected() {
+    when(fakeOpenApiIndexService.isMainOpenApiFile(fakeVirtualFile, fakeProject)).thenReturn(true);
+
+    final boolean isMainSpec = indexService.isMainSpecFile(fakeVirtualFile, fakeProject);
+
+    assertThat(isMainSpec, is(true));
+  }
+
+  @Test
+  public void thatFileThatIsNotMainSpecIsDetected() {
+    when(fakeOpenApiIndexService.isMainOpenApiFile(fakeVirtualFile, fakeProject)).thenReturn(false);
+    when(fakeSwaggerIndexService.isMainSwaggerFile(fakeVirtualFile, fakeProject)).thenReturn(false);
+
+    final boolean isMainSpec = indexService.isMainSpecFile(fakeVirtualFile, fakeProject);
+
+    assertThat(isMainSpec, is(false));
+  }
+}


### PR DESCRIPTION
It seems we can't always use `FileManagerImpl.findFile()` in `SwaggerJsonCatalogExclusion`; the
VirtualFile that is received is not always a physical file
on disc.

Switched to using index service, which does not try
load files from disc.

Fixes #243