### PR TITLE
Add `$ref` resolving for array elements for Swagger UI

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/service/JsonBuilderService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/JsonBuilderService.java
@@ -2,7 +2,9 @@ package org.zalando.intellij.swagger.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.RecursionGuard;
@@ -12,11 +14,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.apache.commons.lang.StringUtils;
+import org.zalando.intellij.swagger.reference.SwaggerConstants;
 
 class JsonBuilderService {
 
-  private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
   /*
    * We need to use a recursion guard because of circular references;
@@ -25,52 +29,83 @@ class JsonBuilderService {
   private static final RecursionGuard recursionGuard =
       RecursionManager.createGuard("JsonBuilderService.buildWithResolvedReferences");
 
-  /*
-   * It is safe to use a cache for already resolved references.
-   */
+  // It is safe to use a cache for already resolved references.
   private static final boolean memoize = true;
 
+  private static final String CIRCULAR_REFERENCE = "Circular reference!";
+
   JsonNode buildWithResolvedReferences(final JsonNode root, final VirtualFile containingFile) {
-
     if (root.isObject()) {
-
-      Iterator<Map.Entry<String, JsonNode>> iterator = root.fields();
-
-      while (iterator.hasNext()) {
-        Map.Entry<String, JsonNode> current = iterator.next();
-
-        final JsonNode ref = current.getValue().get("$ref");
-
-        if (ref != null && ref.isTextual()) {
-          final String text = ref.asText();
-          if (isFileReference(text)) {
-            final Pair<JsonNode, VirtualFile> referencedNode = refToJsonNode(text, containingFile);
-
-            if (referencedNode != null && !referencedNode.first.isMissingNode()) {
-              final JsonNode resolvedValue =
-                  recursionGuard.doPreventingRecursion(
-                      referencedNode,
-                      memoize,
-                      () ->
-                          buildWithResolvedReferences(referencedNode.first, referencedNode.second));
-
-              if (resolvedValue != null) {
-                ((ObjectNode) root).replace(current.getKey(), resolvedValue);
-              } else {
-                ((ObjectNode) root)
-                    .replace(
-                        current.getKey(),
-                        mapper.createObjectNode().put("$ref", "Circular reference!"));
-              }
-            }
-          }
-        } else {
-          buildWithResolvedReferences(current.getValue(), containingFile);
-        }
-      }
+      handleObjectNode((ObjectNode) root, containingFile);
+    } else if (root.isArray()) {
+      handleArrayNode((ArrayNode) root, containingFile);
     }
 
     return root;
+  }
+
+  private void handleObjectNode(final ObjectNode root, final VirtualFile containingFile) {
+    Iterator<Map.Entry<String, JsonNode>> iterator = root.fields();
+
+    while (iterator.hasNext()) {
+      final Map.Entry<String, JsonNode> current = iterator.next();
+      final JsonNode ref = current.getValue().get(SwaggerConstants.REF_KEY);
+
+      if (ref != null && ref.isTextual()) {
+        final String text = ref.asText();
+
+        if (isFileReference(text)) {
+          consumeFileReference(
+              (TextNode) ref, containingFile, new ObjectNodeConsumer(root, current.getKey()));
+        }
+      } else {
+        buildWithResolvedReferences(current.getValue(), containingFile);
+      }
+    }
+  }
+
+  private void handleArrayNode(final ArrayNode root, final VirtualFile containingFile) {
+    final Iterator<JsonNode> iterator = root.iterator();
+    int index = 0;
+
+    while (iterator.hasNext()) {
+      final JsonNode current = iterator.next();
+      final JsonNode ref = current.get(SwaggerConstants.REF_KEY);
+
+      if (ref != null && ref.isTextual()) {
+        final String text = ref.asText();
+
+        if (isFileReference(text)) {
+          consumeFileReference((TextNode) ref, containingFile, new ArrayNodeConsumer(root, index));
+        }
+      }
+      index++;
+    }
+  }
+
+  private void consumeFileReference(
+      final TextNode ref, final VirtualFile containingFile, Consumer<ResolvedRef> refConsumer) {
+    final ResolvedRef resolvedRef = resolveRef(ref.asText(), containingFile);
+
+    if (resolvedRef.isValid()) {
+      final JsonNode node =
+          recursionGuard.doPreventingRecursion(
+              Pair.create(resolvedRef.getJsonNode(), resolvedRef.getContainingFile()),
+              memoize,
+              () ->
+                  buildWithResolvedReferences(
+                      resolvedRef.getJsonNode(), resolvedRef.getContainingFile()));
+
+      // "doPreventingRecursion" returns null in case of a circular reference
+      if (node != null) {
+        refConsumer.accept(resolvedRef);
+      } else {
+        refConsumer.accept(CircularRef.getInstance());
+      }
+
+    } else {
+      refConsumer.accept(resolvedRef);
+    }
   }
 
   private boolean isFileReference(final String text) {
@@ -82,28 +117,155 @@ class JsonBuilderService {
         || text.contains(".yml#/");
   }
 
-  private Pair<JsonNode, VirtualFile> refToJsonNode(
-      final String ref, final VirtualFile containingFile) {
+  private ResolvedRef resolveRef(final String ref, final VirtualFile containingFile) {
 
-    final VirtualFile virtualFile = getVirtualFile(ref, containingFile);
+    final VirtualFile referencedFile = getReferencedFile(ref, containingFile);
 
-    if (virtualFile == null) return null;
+    if (referencedFile == null) return MissingElementRef.getInstance();
 
     final JsonNode tree;
     try {
-      tree = mapper.readTree(new File(virtualFile.getPath()));
+      tree = mapper.readTree(new File(referencedFile.getPath()));
     } catch (IOException e) {
-      return null;
+      return MissingElementRef.getInstance();
     }
 
     final String s = StringUtils.substringAfter(ref, "#");
 
-    return Pair.create(tree.at(s), virtualFile);
+    final JsonNode at = tree.at(s);
+
+    if (at.isMissingNode()) {
+      return MissingElementRef.getInstance();
+    }
+
+    return new ValidRef(at, referencedFile);
   }
 
-  private VirtualFile getVirtualFile(final String ref, final VirtualFile containingFile) {
+  private VirtualFile getReferencedFile(final String ref, final VirtualFile containingFile) {
     final String relativePath = StringUtils.substringBefore(ref, "#");
 
     return containingFile.getParent().findFileByRelativePath(relativePath);
+  }
+
+  private static class ResolvedRef {
+
+    enum ResultType {
+      VALID,
+      CIRCULAR,
+      MISSING_ELEMENT
+    }
+
+    private final ResultType resultType;
+
+    ResolvedRef(final ResultType resultType) {
+      this.resultType = resultType;
+    }
+
+    boolean isValid() {
+      return resultType == ResultType.VALID;
+    }
+
+    boolean isCircular() {
+      return resultType == ResultType.CIRCULAR;
+    }
+
+    JsonNode getJsonNode() {
+      throw new UnsupportedOperationException("Invalid $ref");
+    }
+
+    VirtualFile getContainingFile() {
+      throw new UnsupportedOperationException("Invalid $ref");
+    }
+  }
+
+  private static class ValidRef extends ResolvedRef {
+
+    private final JsonNode jsonNode;
+    private final VirtualFile containingFile;
+
+    private ValidRef(final JsonNode jsonNode, final VirtualFile containingFile) {
+      super(ResultType.VALID);
+      this.jsonNode = jsonNode;
+      this.containingFile = containingFile;
+    }
+
+    boolean isValid() {
+      return true;
+    }
+
+    @Override
+    public JsonNode getJsonNode() {
+      return jsonNode;
+    }
+
+    @Override
+    public VirtualFile getContainingFile() {
+      return containingFile;
+    }
+  }
+
+  private static class MissingElementRef extends ResolvedRef {
+
+    private static final MissingElementRef instance = new MissingElementRef();
+
+    private MissingElementRef() {
+      super(ResultType.MISSING_ELEMENT);
+    }
+
+    private static MissingElementRef getInstance() {
+      return instance;
+    }
+  }
+
+  private static class CircularRef extends ResolvedRef {
+
+    private static final CircularRef instance = new CircularRef();
+
+    private CircularRef() {
+      super(ResultType.CIRCULAR);
+    }
+
+    private static CircularRef getInstance() {
+      return instance;
+    }
+  }
+
+  private static class ArrayNodeConsumer implements Consumer<ResolvedRef> {
+
+    private final ArrayNode node;
+    private final int index;
+
+    private ArrayNodeConsumer(final ArrayNode node, final int index) {
+      this.node = node;
+      this.index = index;
+    }
+
+    public void accept(final ResolvedRef resolvedRef) {
+      if (resolvedRef.isValid()) {
+        node.set(index, resolvedRef.getJsonNode());
+      } else if (resolvedRef.isCircular()) {
+        node.set(
+            index, mapper.createObjectNode().put(SwaggerConstants.REF_KEY, CIRCULAR_REFERENCE));
+      }
+    }
+  }
+
+  private static class ObjectNodeConsumer implements Consumer<ResolvedRef> {
+    private final ObjectNode node;
+    private final String key;
+
+    private ObjectNodeConsumer(final ObjectNode node, final String key) {
+      this.node = node;
+      this.key = key;
+    }
+
+    public void accept(final ResolvedRef resolvedRef) {
+      if (resolvedRef.isValid()) {
+        node.replace(key, resolvedRef.getJsonNode());
+      } else if (resolvedRef.isCircular()) {
+        node.replace(
+            key, mapper.createObjectNode().put(SwaggerConstants.REF_KEY, CIRCULAR_REFERENCE));
+      }
+    }
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>org.zalando.intellij.swagger</id>
     <name>Swagger</name>
-    <version>1.0.25</version>
+    <version>1.0.26</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
     <depends>com.intellij.modules.lang</depends>

--- a/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
@@ -132,6 +132,65 @@ public class JsonBuilderTest {
   }
 
   @Test
+  public void thatReferencesInArrayAreHandled() {
+    final VirtualFile specFile = mock(VirtualFile.class);
+    final VirtualFile parameter1File = mock(VirtualFile.class);
+    final VirtualFile parameter2File = mock(VirtualFile.class);
+    final VirtualFile parameter3File = mock(VirtualFile.class);
+    final VirtualFile parameterSchemaFile = mock(VirtualFile.class);
+
+    when(specFile.getParent()).thenReturn(specFile);
+    when(parameter1File.getParent()).thenReturn(parameter1File);
+    when(parameter2File.getParent()).thenReturn(parameter2File);
+    when(parameter3File.getParent()).thenReturn(parameter3File);
+    when(parameterSchemaFile.getParent()).thenReturn(parameterSchemaFile);
+
+    when(specFile.findFileByRelativePath("partial/Parameter_1.json")).thenReturn(parameter1File);
+    when(parameter1File.getPath()).thenReturn(getUrl("partial/Parameter_1.json").getPath());
+
+    when(specFile.findFileByRelativePath("partial/Parameter_2.json")).thenReturn(parameter2File);
+    when(parameter2File.getPath()).thenReturn(getUrl("partial/Parameter_2.json").getPath());
+
+    when(specFile.findFileByRelativePath("partial/Parameter_3.json")).thenReturn(parameter3File);
+    when(parameter3File.getPath()).thenReturn(getUrl("partial/Parameter_3.json").getPath());
+
+    when(parameter3File.findFileByRelativePath("Parameter_schema.json"))
+        .thenReturn(parameterSchemaFile);
+    when(parameterSchemaFile.getPath())
+        .thenReturn(getUrl("partial/Parameter_schema.json").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_7.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, specFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_7_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatCircularReferenceInArrayIsHandled() {
+    final VirtualFile specFile = mock(VirtualFile.class);
+    final VirtualFile parameter4File = mock(VirtualFile.class);
+
+    when(specFile.getParent()).thenReturn(specFile);
+    when(parameter4File.getParent()).thenReturn(parameter4File);
+
+    when(specFile.findFileByRelativePath("partial/Parameter_4.json")).thenReturn(parameter4File);
+    when(parameter4File.getPath()).thenReturn(getUrl("partial/Parameter_4.json").getPath());
+
+    when(parameter4File.findFileByRelativePath("Parameter_4.json")).thenReturn(parameter4File);
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_8.json");
+
+    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, specFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_8_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
   public void thatYamlFileWithDepthOneReferenceIsHandled() {
     when(fakeVirtualFile.findFileByRelativePath(anyString())).thenReturn(fakeVirtualFile2);
     when(fakeVirtualFile2.getPath()).thenReturn(getUrl("partial/Error.yaml").getPath());

--- a/src/test/resources/service/json/partial/Parameter_1.json
+++ b/src/test/resources/service/json/partial/Parameter_1.json
@@ -1,0 +1,7 @@
+{
+  "name": "parameter1",
+  "in": "path",
+  "required": true,
+  "description": "The id of the pet to retrieve",
+  "type": "string"
+}

--- a/src/test/resources/service/json/partial/Parameter_2.json
+++ b/src/test/resources/service/json/partial/Parameter_2.json
@@ -1,0 +1,9 @@
+{
+  "Parameter": {
+    "name": "parameter2",
+    "in": "path",
+    "required": true,
+    "description": "The id of the pet to retrieve",
+    "type": "string"
+  }
+}

--- a/src/test/resources/service/json/partial/Parameter_3.json
+++ b/src/test/resources/service/json/partial/Parameter_3.json
@@ -1,0 +1,6 @@
+{
+  "in": "body",
+  "schema": {
+    "$ref": "Parameter_schema.json"
+  }
+}

--- a/src/test/resources/service/json/partial/Parameter_4.json
+++ b/src/test/resources/service/json/partial/Parameter_4.json
@@ -1,0 +1,6 @@
+{
+  "in": "body",
+  "schema": {
+    "$ref": "Parameter_4.json"
+  }
+}

--- a/src/test/resources/service/json/partial/Parameter_schema.json
+++ b/src/test/resources/service/json/partial/Parameter_schema.json
@@ -1,0 +1,11 @@
+{
+  "required": [
+    "param"
+  ],
+  "properties": {
+    "param": {
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_7.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_7.json
@@ -1,0 +1,129 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "$ref": "partial/Parameter_1.json"
+          },
+          {
+            "$ref": "partial/Parameter_2.json#/Parameter"
+          },
+          {
+            "$ref": "partial/Parameter_3.json"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_7_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_7_after.json
@@ -1,0 +1,148 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "parameter1",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          },
+          {
+            "name": "parameter2",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "schema": {
+              "required": [
+                "param"
+              ],
+              "properties": {
+                "param": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_8.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_8.json
@@ -1,0 +1,115 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "$ref": "partial/Parameter_4.json"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_8_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_8_after.json
@@ -1,0 +1,118 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "schema": {
+              "$ref": "Circular reference!"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    }
+  }
+}


### PR DESCRIPTION
References can be included in array elements,
for example in the case of parameters:

```json
"paths": {
  "/pets": {
    "get": {
      "summary": "List all pets",
      "operationId": "listPets",
      "tags": [
        "pets"
      ],
      "parameters": [
        {
          "$ref": "partial/Parameter_1.json"
        }
...
```

This commit adds the logic for handling $ref elements in arrays.

Part of #184