### PR TITLE
Fix zalando extensions compatibility issue

### DIFF
--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -4,6 +4,7 @@
     <version>0.0.4</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
+    <depends>com.intellij.modules.lang</depends>
     <depends>org.zalando.intellij.swagger</depends>
 
     <description><![CDATA[


### PR DESCRIPTION
As documented in https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
there needs to be a `com.intellij.modules.lang` dependency
in order for the plugin to work across all JetBrains products.

Fixes #249