### PR TITLE
Inline references in referenced files

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/SwaggerFileService.java
@@ -89,7 +89,7 @@ public class SwaggerFileService {
 
   private String convertToJsonIfNecessary(@NotNull final VirtualFile virtualFile) throws Exception {
     final JsonNode root = mapper.readTree(LoadTextUtil.loadText(virtualFile).toString());
-    final JsonNode result = jsonBuilderService.buildWithResolvedReferences(root, virtualFile);
+    final JsonNode result = jsonBuilderService.buildFromSpec(root, virtualFile);
 
     return new ObjectMapper().writeValueAsString(result);
   }

--- a/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/service/JsonBuilderTest.java
@@ -31,7 +31,7 @@ public class JsonBuilderTest {
   public void thatFileWithoutFileReferencesIsHandled() {
     final JsonNode jsonNode = getJsonNode("petstore.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore.json");
 
@@ -45,7 +45,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_1.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_1_after.json");
 
@@ -63,7 +63,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_2.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_2_after.json");
 
@@ -76,7 +76,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_3.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_3_after.json");
 
@@ -90,7 +90,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_4.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_4_after.json");
 
@@ -104,7 +104,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_6.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_6_after.json");
 
@@ -124,7 +124,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_5.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_5_after.json");
 
@@ -161,7 +161,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_7.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, specFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, specFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_7_after.json");
 
@@ -183,7 +183,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_8.json");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, specFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, specFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_8_after.json");
 
@@ -197,7 +197,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_1.yaml");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_1_after.json");
 
@@ -215,7 +215,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_2.yaml");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_2_after.json");
 
@@ -228,7 +228,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_3.yaml");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_3_yaml_after.json");
 
@@ -242,7 +242,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_4.yaml");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_4_yaml_after.json");
 
@@ -256,7 +256,7 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_6.yaml");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_6_after.json");
 
@@ -276,9 +276,28 @@ public class JsonBuilderTest {
 
     final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_5.yaml");
 
-    JsonNode result = jsonBuilderService.buildWithResolvedReferences(jsonNode, fakeVirtualFile);
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, fakeVirtualFile);
 
     JsonNode expected = getJsonNode("petstore_with_file_ref_5_after.json");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void thatLocalReferenceInReferencedFileIsHandled() {
+    final VirtualFile specFile = mock(VirtualFile.class);
+    final VirtualFile refFile = mock(VirtualFile.class);
+
+    when(specFile.getParent()).thenReturn(specFile);
+
+    when(specFile.findFileByRelativePath("partial/Pets.json")).thenReturn(refFile);
+    when(refFile.getPath()).thenReturn(getUrl("partial/Pets.json").getPath());
+
+    final JsonNode jsonNode = getJsonNode("petstore_with_file_ref_9.json");
+
+    JsonNode result = jsonBuilderService.buildFromSpec(jsonNode, specFile);
+
+    JsonNode expected = getJsonNode("petstore_with_file_ref_9_after.json");
 
     assertEquals(expected, result);
   }

--- a/src/test/resources/service/json/partial/Pets.json
+++ b/src/test/resources/service/json/partial/Pets.json
@@ -1,0 +1,16 @@
+{
+  "Dogs": {
+    "type": "array",
+    "items": {
+      "$ref": "#/Dog"
+    }
+  },
+  "Dog": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_9.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_9.json
@@ -1,0 +1,40 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "schema": {
+              "$ref": "partial/Pets.json#/Dogs"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/service/json/petstore_with_file_ref_9_after.json
+++ b/src/test/resources/service/json/petstore_with_file_ref_9_after.json
@@ -1,0 +1,48 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We need to inline references in referenced files in order
for the Swagger UI to display them.