### PR TITLE
Unescape JSON pointers in references

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/reference/FileReference.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/FileReference.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.zalando.intellij.swagger.traversal.path.PathExpressionUtil;
 import org.zalando.intellij.swagger.traversal.path.PathFinder;
 
 public class FileReference extends PsiReferenceBase<PsiElement> {
@@ -42,7 +43,7 @@ public class FileReference extends PsiReferenceBase<PsiElement> {
     String textAfterRelativePath = StringUtils.substringAfter(originalRefValue, relativePath);
     final String pathExpression =
         Arrays.stream(textAfterRelativePath.substring(2).split("/"))
-            .map(s -> s.replace(".", "\\."))
+            .map(PathExpressionUtil::escape)
             .collect(Collectors.joining(".", "$.", ""));
 
     return getReferencedFile(relativePath)

--- a/src/main/java/org/zalando/intellij/swagger/reference/LocalReference.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/LocalReference.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.zalando.intellij.swagger.traversal.path.PathExpressionUtil;
 import org.zalando.intellij.swagger.traversal.path.PathFinder;
 
 public class LocalReference extends PsiReferenceBase<PsiElement> {
@@ -27,7 +28,7 @@ public class LocalReference extends PsiReferenceBase<PsiElement> {
   public PsiElement resolve() {
     final String pathExpression =
         Arrays.stream(originalRefValue.substring(2, originalRefValue.length()).split("/"))
-            .map(s -> s.replace(".", "\\."))
+            .map(PathExpressionUtil::escape)
             .collect(Collectors.joining(".", "$.", ""));
 
     final PsiFile psiFile = getElement().getContainingFile();

--- a/src/main/java/org/zalando/intellij/swagger/reference/SchemaNameReference.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/SchemaNameReference.java
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiReferenceBase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.zalando.intellij.swagger.traversal.path.PathExpressionUtil;
 import org.zalando.intellij.swagger.traversal.path.PathFinder;
 
 public class SchemaNameReference extends PsiReferenceBase<PsiElement> {
@@ -20,7 +21,7 @@ public class SchemaNameReference extends PsiReferenceBase<PsiElement> {
   @Nullable
   @Override
   public PsiElement resolve() {
-    final String escaped = originalRefValue.replace(".", "\\.");
+    final String escaped = PathExpressionUtil.escape(originalRefValue);
     final String pathExpression = String.format("$.components.schemas.%s", escaped);
 
     final PsiFile psiFile = getElement().getContainingFile();

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/PathExpressionUtil.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/PathExpressionUtil.java
@@ -1,0 +1,17 @@
+package org.zalando.intellij.swagger.traversal.path;
+
+public class PathExpressionUtil {
+
+  public static String unescape(final String part) {
+
+    // Unescape JSON pointer (https://tools.ietf.org/html/rfc6901)
+    final String result = part.replace("~1", "/").replace("~0", "~");
+
+    // Unescape dots that are used for splitting parts
+    return result.replace("\\.", ".");
+  }
+
+  public static String escape(final String part) {
+    return part.replace(".", "\\.");
+  }
+}

--- a/src/main/java/org/zalando/intellij/swagger/traversal/path/PathFinder.java
+++ b/src/main/java/org/zalando/intellij/swagger/traversal/path/PathFinder.java
@@ -1,5 +1,7 @@
 package org.zalando.intellij.swagger.traversal.path;
 
+import static org.zalando.intellij.swagger.traversal.path.PathExpressionUtil.*;
+
 import com.intellij.json.psi.JsonArray;
 import com.intellij.json.psi.JsonObject;
 import com.intellij.json.psi.JsonStringLiteral;
@@ -76,7 +78,7 @@ public class PathFinder {
     }
 
     final PsiNamedElement nextNamedParent = getNextNamedParent(psiElement);
-    final String unescapedTargetKeyName = unescapedName(pathExpression.last());
+    final String unescapedTargetKeyName = unescape(pathExpression.last());
 
     if (pathExpression.isAnyKey()) {
       return isInsidePath(
@@ -111,7 +113,7 @@ public class PathFinder {
     if (psiElement instanceof PsiNamedElement) {
       final PsiNamedElement psiNamedElement = (PsiNamedElement) psiElement;
 
-      if (unescapedName(keyName).equals(psiNamedElement.getName())) {
+      if (unescape(keyName).equals(psiNamedElement.getName())) {
         return (PsiNamedElement) psiElement;
       } else if (keyName.equals(ROOT_PATH)) {
         return isRoot(psiElement)
@@ -228,13 +230,9 @@ public class PathFinder {
           : Optional.empty();
     }
 
-    final String unescapedName = unescapedName(name);
+    final String unescapedName = unescape(name);
 
     return children.stream().filter(child -> unescapedName.equals(child.getName())).findFirst();
-  }
-
-  private String unescapedName(final String name) {
-    return name.replace("\\.", ".");
   }
 
   private PsiElement getNextObjectParent(final PsiElement psiElement) {

--- a/src/test/java/org/zalando/intellij/swagger/reference/ResolveTest.java
+++ b/src/test/java/org/zalando/intellij/swagger/reference/ResolveTest.java
@@ -1,0 +1,20 @@
+package org.zalando.intellij.swagger.reference;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.yaml.psi.YAMLKeyValue;
+import org.zalando.intellij.swagger.SwaggerLightCodeInsightFixtureTestCase;
+
+public class ResolveTest extends SwaggerLightCodeInsightFixtureTestCase {
+
+  public void testReferenceWithSlashWorks() {
+    final PsiFile psiFile = myFixture.configureByFile("reference/slashes.yaml");
+
+    final PsiElement originalElement =
+        psiFile.findElementAt(myFixture.getEditor().getCaretModel().getOffset()).getParent();
+
+    final PsiElement targetElement = originalElement.getReferences()[0].resolve();
+
+    assertEquals("/bar", ((YAMLKeyValue) targetElement).getKeyText());
+  }
+}

--- a/src/test/resources/testing/reference/slashes.yaml
+++ b/src/test/resources/testing/reference/slashes.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.2
+info:
+  title: Title
+  description: Description
+  version: 1.0.0
+paths:
+  '/foo':
+    $ref: '#/paths/~1bar<caret>'
+  '/bar':


### PR DESCRIPTION
In order to allow slashes in referenced keys,
we need to properly unescape JSON pointers.

An example case:

```yaml
paths:
  '/foo':
    $ref: '#/paths/~1bar<caret>'
  '/bar':

```

`~1bar` needs to be converted to `/bar` in order
for the element to be located.

Fixes #247