### PR TITLE
Fix regex for reference contributors

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/reference/JsonReferenceContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/JsonReferenceContributor.java
@@ -17,7 +17,7 @@ public class JsonReferenceContributor extends ReferenceContributor {
       StandardPatterns.string().matches("^\"https://(.)*");
 
   private static final StringPattern JSON_FILE_NAME_PATTERN =
-      StandardPatterns.string().matches("(.)*.json(.)*");
+      StandardPatterns.string().matches("(.)*\\.json(.)*");
 
   @Override
   public void registerReferenceProviders(@NotNull final PsiReferenceRegistrar registrar) {

--- a/src/main/java/org/zalando/intellij/swagger/reference/YamlReferenceContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/YamlReferenceContributor.java
@@ -17,7 +17,7 @@ public class YamlReferenceContributor extends ReferenceContributor {
       StandardPatterns.string().matches("^(\"|\')?https://(.)*");
 
   private static final StringPattern YAML_FILE_NAME_PATTERN =
-      StandardPatterns.string().matches("(.)*.ya?ml(.)*");
+      StandardPatterns.string().matches("(.)*\\.ya?ml(.)*");
 
   @Override
   public void registerReferenceProviders(@NotNull final PsiReferenceRegistrar registrar) {

--- a/src/test/resources/testing/validator/file_detection/no_errors.json
+++ b/src/test/resources/testing/validator/file_detection/no_errors.json
@@ -99,6 +99,14 @@
                 }
               }
             }
+          },
+          "404": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/name_with_json"
+              }
+            }
           }
         }
       }
@@ -179,6 +187,7 @@
           "type": "string"
         }
       }
-    }
+    },
+    "name_with_json": {}
   }
 }

--- a/src/test/resources/testing/validator/file_detection/no_errors.yaml
+++ b/src/test/resources/testing/validator/file_detection/no_errors.yaml
@@ -77,6 +77,11 @@ paths:
                   format": int32
                 name:
                   type: string
+        404:
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/name_with_yaml"
 securityDefinitions:
   githubAccessCode:
     type: "oauth2"
@@ -140,3 +145,4 @@ definitions:
         type: "string"
       tag:
         type: "string"
+  name_with_yaml:


### PR DESCRIPTION
This commit fixes the issue of resolving references that
contain a `json` or `yaml` substrings. The fix is to
escape the dot that was previously treated as any character
in regex.

Fixes #270