### PR TITLE
Fix `runReadAction()` in references search

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/reference/usage/SpecReferenceSearch.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/usage/SpecReferenceSearch.java
@@ -13,10 +13,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.psi.YAMLKeyValue;
 import org.zalando.intellij.swagger.traversal.path.PathExpressionUtil;
 
-public class ReferenceSearch
+public class SpecReferenceSearch
     extends QueryExecutorBase<PsiReference, ReferencesSearch.SearchParameters> {
 
   private static final boolean CASE_SENSITIVE = false;
+  private static final boolean REQUIRE_READ_ACTION = true;
+
+  public SpecReferenceSearch() {
+    super(REQUIRE_READ_ACTION);
+  }
 
   @Override
   public void processQuery(

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -90,7 +90,7 @@
                          level="ERROR"
                          implementationClass="org.zalando.intellij.swagger.inspection.reference.JsonReferenceInspection"/>
 
-        <referencesSearch implementation="org.zalando.intellij.swagger.reference.usage.ReferenceSearch"/>
+        <referencesSearch implementation="org.zalando.intellij.swagger.reference.usage.SpecReferenceSearch"/>
     </extensions>
     <actions>
         <action id="SwaggerPlugin.CreateSwaggerFile" class="CreateSwaggerFile" text="Swagger/OpenAPI File"


### PR DESCRIPTION
Make sure that references are searched only in a read action
by providing the needed boolean flag.

Fixes #272