### PR TITLE
Fix high CPU usage

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/reference/usage/SpecReferenceSearch.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/usage/SpecReferenceSearch.java
@@ -2,6 +2,8 @@ package org.zalando.intellij.swagger.reference.usage;
 
 import com.intellij.json.psi.JsonProperty;
 import com.intellij.openapi.application.QueryExecutorBase;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.PsiReference;
@@ -11,6 +13,7 @@ import com.intellij.util.Processor;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.psi.YAMLKeyValue;
+import org.zalando.intellij.swagger.index.IndexFacade;
 import org.zalando.intellij.swagger.traversal.path.PathExpressionUtil;
 
 public class SpecReferenceSearch
@@ -18,9 +21,12 @@ public class SpecReferenceSearch
 
   private static final boolean CASE_SENSITIVE = false;
   private static final boolean REQUIRE_READ_ACTION = true;
+  private IndexFacade indexFacade;
 
-  public SpecReferenceSearch() {
+  public SpecReferenceSearch(final IndexFacade indexFacade) {
     super(REQUIRE_READ_ACTION);
+
+    this.indexFacade = indexFacade;
   }
 
   @Override
@@ -29,17 +35,44 @@ public class SpecReferenceSearch
       @NotNull final Processor<? super PsiReference> consumer) {
     final PsiElement elementToSearch = queryParameters.getElementToSearch();
 
-    if (elementToSearch instanceof YAMLKeyValue || elementToSearch instanceof JsonProperty) {
-      Optional.ofNullable(((PsiNamedElement) elementToSearch).getName())
-          .ifPresent(
-              word ->
-                  queryParameters
-                      .getOptimizer()
-                      .searchWord(
-                          PathExpressionUtil.escapeJsonPointer(word),
-                          GlobalSearchScope.allScope(queryParameters.getProject()),
-                          CASE_SENSITIVE,
-                          elementToSearch));
+    final Project project = queryParameters.getProject();
+
+    if (indexFacade.isIndexReady(project)) {
+      if (isSpec(elementToSearch, project)) {
+        process(queryParameters, elementToSearch, project);
+      }
     }
+  }
+
+  private void process(
+      final ReferencesSearch.SearchParameters queryParameters,
+      final PsiElement elementToSearch,
+      final Project project) {
+    Optional.ofNullable(((PsiNamedElement) elementToSearch).getName())
+        .ifPresent(
+            word -> {
+              final String escaped = PathExpressionUtil.escapeJsonPointer(word);
+
+              if (!escaped.equals(word)) {
+                queryParameters
+                    .getOptimizer()
+                    .searchWord(
+                        escaped,
+                        GlobalSearchScope.allScope(project),
+                        CASE_SENSITIVE,
+                        elementToSearch);
+              }
+            });
+  }
+
+  private boolean isSpec(final PsiElement elementToSearch, final Project project) {
+    if (elementToSearch instanceof YAMLKeyValue || elementToSearch instanceof JsonProperty) {
+      final VirtualFile virtualFile = elementToSearch.getContainingFile().getVirtualFile();
+
+      return indexFacade.isMainSpecFile(virtualFile, project)
+          || indexFacade.isPartialSpecFile(virtualFile, project);
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
Before searching for references, we should verify
that the file is a specification file and that
the escaped key is different from the original one.
Otherwise, we do not need to execute an escaped JSON
pointer search.

Fixes #263