### PR TITLE
Update to Idea 2022.x and enable plugin version patching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ intellij {
     //Bundled plugin dependencies
     plugins.set(listOf("yaml", "com.intellij.java", "org.jetbrains.plugins.yaml"))
     pluginName.set("intellij-swagger")
-    version.set("2022.1") // Recommended to use the lowest supported to compile against
+    version.set("2022.1") // Recommended to use the lowest supported version to compile against
 }
 
 group = "org.zalando.intellij"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,7 @@ intellij {
     //Bundled plugin dependencies
     plugins.set(listOf("yaml", "com.intellij.java", "org.jetbrains.plugins.yaml"))
     pluginName.set("intellij-swagger")
-    updateSinceUntilBuild.set(false)
-    version.set("2021.1")
+    version.set("2022.1") // Recommended to use the lowest supported to compile against
 }
 
 group = "org.zalando.intellij"
@@ -57,8 +56,10 @@ tasks {
         channels.set(listOf("beta"))
         token.set(System.getenv("JETBRAINS_HUB_TOKEN"))
     }
+    patchPluginXml {
+        untilBuild.set("") // null will add until-build to the plugin.xml
+    }
 }
-
 
 spotless {
     java {

--- a/examples/extensions-zalando/README.md
+++ b/examples/extensions-zalando/README.md
@@ -5,13 +5,26 @@ Zalando's architecture centers around microservices, and each API is documented 
 
 ## Development
 
-Developing the Swagger Plugin is easy, just execute the following command:
-
+### Running the IDE
+To start IntelliJ IDEA with the plugin installed:
 ```sh
 ./gradlew runIde
 ```
 
-This will start IntelliJ IDEA with the plugin installed.
+### Plugin verification
+To verify the plugin against different IDEA versions run:
+```sh
+./gradlew runPluginVerifier
+```
+This will output information of compatibility and also create reports under `./build/reports/pluginVerifier/`.
+
+Generic verification:
+```sh
+./gradlew check
+```
+
+### Releasing
+See `./release.sh`
 
 ###
 Check dependency updates (preferably replaced with Dependabot):

--- a/examples/extensions-zalando/build.gradle
+++ b/examples/extensions-zalando/build.gradle
@@ -16,15 +16,14 @@ apply plugin: 'java'
 intellij {
     plugins = ['org.zalando.intellij.swagger:1.1.2', 'yaml']
     pluginName = 'intellij-swagger-extensions-zalando'
-    updateSinceUntilBuild = false
-    version = '2016.2'
+    version = '2022.1'
 }
 
 group 'org.zalando.intellij.examples.extensions'
 version = project.hasProperty('version') ? project['version'] : '0.0.1'
 
 apply plugin: 'java'
-sourceCompatibility = 1.8
+sourceCompatibility = 11
 
 repositories {
     mavenCentral()

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
         such as <a href="https://opensource.zalando.com/zally">Zally</a> linting.
     ]]></description>
 
-    <idea-version since-build="211"/>
+    <idea-version since-build="will-be-patched-by-patchPluginXml"/>
 
     <extensions defaultExtensionNs="org.zalando.intellij.swagger">
         <customFieldFactory implementation="org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.swagger.SwaggerFieldFactory" />

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
         such as <a href="https://opensource.zalando.com/zally">Zally</a> linting.
     ]]></description>
 
-    <idea-version since-build="will-be-patched-by-patchPluginXml"/>
+    <idea-version since-build="2022.1"/> <!-- since-build will be patched by the build -->
 
     <extensions defaultExtensionNs="org.zalando.intellij.swagger">
         <customFieldFactory implementation="org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.swagger.SwaggerFieldFactory" />

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,7 +14,7 @@
     ]]></description>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="211"/>
+    <idea-version/>
 
     <extensionPoints>
         <extensionPoint qualifiedName="org.zalando.intellij.swagger.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin version="2">
+<idea-plugin>
     <id>org.zalando.intellij.swagger</id>
     <name>Swagger</name>
     <version>1.1.2</version>
@@ -14,7 +14,7 @@
     ]]></description>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version/>
+    <idea-version since-build="2022.1"/> <!-- since-build will be patched by the build -->
 
     <extensionPoints>
         <extensionPoint qualifiedName="org.zalando.intellij.swagger.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory"/>


### PR DESCRIPTION
- Drop support of 2021.* (perhaps just supporting 2022.3.* would be enough?)
- Enable plugin.xml patching to verifying against multiple IDEA versions
- Update readme

Plugin Verifier results:
```
IC-223.8836.35 against org.zalando.intellij.swagger:1.1.2: Compatible. 19 usages of deprecated API
IC-231.8109.2 against org.zalando.intellij.swagger:1.1.2: Compatible. 20 usages of deprecated API
IC-222.4459.24 against org.zalando.intellij.swagger:1.1.2: Compatible. 19 usages of deprecated API
IC-221.6008.13 against org.zalando.intellij.swagger:1.1.2: Compatible. 19 usages of deprecated API
```