### PR TITLE
Fix deprecation warnings reported by plugin verifier

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/SwaggerJsonCatalogExclusion.java
+++ b/src/main/java/org/zalando/intellij/swagger/SwaggerJsonCatalogExclusion.java
@@ -1,6 +1,6 @@
 package org.zalando.intellij.swagger;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -13,9 +13,9 @@ public class SwaggerJsonCatalogExclusion implements JsonSchemaCatalogExclusion {
   @Override
   public boolean isExcluded(@NotNull VirtualFile file) {
     final Project[] openProjects =
-        ServiceManager.getService(ProjectManager.class).getOpenProjects();
+      ApplicationManager.getApplication().getService(ProjectManager.class).getOpenProjects();
 
-    IndexFacade indexFacade = ServiceManager.getService(IndexFacade.class);
+    IndexFacade indexFacade = ApplicationManager.getApplication().getService(IndexFacade.class);
     if (openProjects.length > 0 && indexFacade.isIndexReady(openProjects[0])) {
       return indexFacade.isMainSpecFile(file, openProjects[0]);
     }

--- a/src/main/java/org/zalando/intellij/swagger/annotator/swagger/UnusedRefAnnotator.java
+++ b/src/main/java/org/zalando/intellij/swagger/annotator/swagger/UnusedRefAnnotator.java
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.search.searches.ReferencesSearch;
@@ -76,8 +77,10 @@ public abstract class UnusedRefAnnotator implements Annotator {
     final PsiReference first = ReferencesSearch.search(searchableCurrentElement).findFirst();
 
     if (first == null) {
-      Annotation annotation = annotationHolder.createWeakWarningAnnotation(psiElement, warning);
-      annotation.setHighlightType(ProblemHighlightType.LIKE_UNUSED_SYMBOL);
+      annotationHolder
+        .newAnnotation(HighlightSeverity.WEAK_WARNING, warning)
+        .highlightType(ProblemHighlightType.LIKE_UNUSED_SYMBOL)
+        .create();
     }
   }
 }

--- a/src/main/java/org/zalando/intellij/swagger/documentation/openapi/OpenApiDocumentationProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/documentation/openapi/OpenApiDocumentationProvider.java
@@ -1,6 +1,6 @@
 package org.zalando.intellij.swagger.documentation.openapi;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
@@ -33,7 +33,7 @@ public class OpenApiDocumentationProvider extends ApiDocumentProvider {
               final Project project = maybeProject.get();
 
               final Optional<OpenApiFileType> maybeFileType =
-                  ServiceManager.getService(OpenApiIndexService.class)
+                ApplicationManager.getApplication().getService(OpenApiIndexService.class)
                       .getFileType(project, virtualFile);
 
               return maybeFileType.map(

--- a/src/main/java/org/zalando/intellij/swagger/file/icon/OpenApiIconProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/file/icon/OpenApiIconProvider.java
@@ -1,6 +1,6 @@
 package org.zalando.intellij.swagger.file.icon;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import javax.swing.Icon;
 import org.zalando.intellij.swagger.index.IndexService;
 import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
@@ -14,6 +14,6 @@ public class OpenApiIconProvider extends SpecIconProvider {
 
   @Override
   protected IndexService getIndexService() {
-    return ServiceManager.getService(OpenApiIndexService.class);
+    return ApplicationManager.getApplication().getService(OpenApiIndexService.class);
   }
 }

--- a/src/main/java/org/zalando/intellij/swagger/file/icon/SwaggerIconProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/file/icon/SwaggerIconProvider.java
@@ -1,6 +1,8 @@
 package org.zalando.intellij.swagger.file.icon;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
 import javax.swing.Icon;
 import org.zalando.intellij.swagger.index.IndexService;
 import org.zalando.intellij.swagger.index.swagger.SwaggerIndexService;
@@ -14,6 +16,6 @@ public class SwaggerIconProvider extends SpecIconProvider {
 
   @Override
   protected IndexService getIndexService() {
-    return ServiceManager.getService(SwaggerIndexService.class);
+    return ApplicationManager.getApplication().getService(SwaggerIndexService.class);
   }
 }

--- a/src/main/java/org/zalando/intellij/swagger/index/IndexFacade.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/IndexFacade.java
@@ -1,6 +1,6 @@
 package org.zalando.intellij.swagger.index;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
@@ -15,8 +15,8 @@ public class IndexFacade {
     final VirtualFile virtualFile = psiFile.getVirtualFile();
     final Project project = psiFile.getProject();
 
-    OpenApiIndexService openApiIndexService = ServiceManager.getService(OpenApiIndexService.class);
-    SwaggerIndexService swaggerIndexService = ServiceManager.getService(SwaggerIndexService.class);
+    OpenApiIndexService openApiIndexService = ApplicationManager.getApplication().getService(OpenApiIndexService.class);
+    SwaggerIndexService swaggerIndexService = ApplicationManager.getApplication().getService(SwaggerIndexService.class);
 
     if (isMainSpecFile(virtualFile, project)) {
       return Optional.of(psiFile.getVirtualFile());
@@ -30,19 +30,19 @@ public class IndexFacade {
   }
 
   public boolean isMainSpecFile(final VirtualFile virtualFile, final Project project) {
-    return ServiceManager.getService(OpenApiIndexService.class).isMainSpecFile(virtualFile, project)
-        || ServiceManager.getService(SwaggerIndexService.class)
+    return ApplicationManager.getApplication().getService(OpenApiIndexService.class).isMainSpecFile(virtualFile, project)
+        || ApplicationManager.getApplication().getService(SwaggerIndexService.class)
             .isMainSpecFile(virtualFile, project);
   }
 
   public boolean isPartialSpecFile(final VirtualFile virtualFile, final Project project) {
-    return ServiceManager.getService(OpenApiIndexService.class)
+    return ApplicationManager.getApplication().getService(OpenApiIndexService.class)
             .isPartialSpecFile(virtualFile, project)
-        || ServiceManager.getService(SwaggerIndexService.class)
+        || ApplicationManager.getApplication().getService(SwaggerIndexService.class)
             .isPartialSpecFile(virtualFile, project);
   }
 
   public boolean isIndexReady(final Project project) {
-    return !ServiceManager.getService(DumbService.class).isDumb(project);
+    return !ApplicationManager.getApplication().getService(DumbService.class).isDumb(project);
   }
 }

--- a/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiFileIndex.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/openapi/OpenApiFileIndex.java
@@ -1,6 +1,5 @@
 package org.zalando.intellij.swagger.index.openapi;
 
-import com.intellij.util.containers.HashSet;
 import com.intellij.util.indexing.*;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
@@ -8,6 +7,7 @@ import com.intellij.util.io.KeyDescriptor;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.file.FileDetector;

--- a/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerFileIndex.java
+++ b/src/main/java/org/zalando/intellij/swagger/index/swagger/SwaggerFileIndex.java
@@ -1,6 +1,5 @@
 package org.zalando.intellij.swagger.index.swagger;
 
-import com.intellij.util.containers.HashSet;
 import com.intellij.util.indexing.*;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
@@ -8,6 +7,7 @@ import com.intellij.util.io.KeyDescriptor;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.intellij.swagger.file.FileDetector;

--- a/src/main/java/org/zalando/intellij/swagger/inspection/reference/JsonReferenceInspection.java
+++ b/src/main/java/org/zalando/intellij/swagger/inspection/reference/JsonReferenceInspection.java
@@ -6,7 +6,7 @@ import com.intellij.json.psi.JsonElementVisitor;
 import com.intellij.json.psi.JsonProperty;
 import com.intellij.json.psi.JsonStringLiteral;
 import com.intellij.json.psi.JsonValue;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -27,7 +27,7 @@ public class JsonReferenceInspection extends ReferenceInspection {
     final PsiFile file = holder.getFile();
     final VirtualFile virtualFile = file.getVirtualFile();
     final Project project = holder.getProject();
-    IndexFacade indexFacade = ServiceManager.getService(IndexFacade.class);
+    IndexFacade indexFacade = ApplicationManager.getApplication().getService(IndexFacade.class);
 
     boolean checkRefs =
         indexFacade.isMainSpecFile(virtualFile, project)

--- a/src/main/java/org/zalando/intellij/swagger/inspection/reference/YamlReferenceInspection.java
+++ b/src/main/java/org/zalando/intellij/swagger/inspection/reference/YamlReferenceInspection.java
@@ -2,7 +2,7 @@ package org.zalando.intellij.swagger.inspection.reference;
 
 import com.intellij.codeInspection.LocalInspectionToolSession;
 import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -28,7 +28,7 @@ public class YamlReferenceInspection extends ReferenceInspection {
     final VirtualFile virtualFile = file.getVirtualFile();
     final Project project = holder.getProject();
 
-    IndexFacade indexFacade = ServiceManager.getService(IndexFacade.class);
+    IndexFacade indexFacade = ApplicationManager.getApplication().getService(IndexFacade.class);
     boolean checkRefs =
         indexFacade.isMainSpecFile(virtualFile, project)
             || indexFacade.isPartialSpecFile(virtualFile, project);

--- a/src/main/java/org/zalando/intellij/swagger/reference/usage/SpecReferenceSearch.java
+++ b/src/main/java/org/zalando/intellij/swagger/reference/usage/SpecReferenceSearch.java
@@ -1,8 +1,8 @@
 package org.zalando.intellij.swagger.reference.usage;
 
 import com.intellij.json.psi.JsonProperty;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.QueryExecutorBase;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
@@ -35,7 +35,7 @@ public class SpecReferenceSearch
 
     final Project project = queryParameters.getProject();
 
-    if (ServiceManager.getService(IndexFacade.class).isIndexReady(project)) {
+    if (ApplicationManager.getApplication().getService(IndexFacade.class).isIndexReady(project)) {
       if (isSpec(elementToSearch, project)) {
         process(queryParameters, elementToSearch, project);
       }
@@ -67,7 +67,7 @@ public class SpecReferenceSearch
     if (elementToSearch instanceof YAMLKeyValue || elementToSearch instanceof JsonProperty) {
       final VirtualFile virtualFile = elementToSearch.getContainingFile().getVirtualFile();
 
-      IndexFacade indexFacade = ServiceManager.getService(IndexFacade.class);
+      IndexFacade indexFacade = ApplicationManager.getApplication().getService(IndexFacade.class);
       return indexFacade.isMainSpecFile(virtualFile, project)
           || indexFacade.isPartialSpecFile(virtualFile, project);
     }

--- a/src/main/java/org/zalando/intellij/swagger/service/PsiFileService.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/PsiFileService.java
@@ -1,6 +1,6 @@
 package org.zalando.intellij.swagger.service;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -12,13 +12,13 @@ public class PsiFileService {
 
   public Optional<PsiFile> fromDocument(final Document document) {
     final Project[] openProjects =
-        ServiceManager.getService(ProjectManager.class).getOpenProjects();
+      ApplicationManager.getApplication().getService(ProjectManager.class).getOpenProjects();
 
     if (openProjects.length > 0) {
       final Project openProject = openProjects[0];
 
       return Optional.ofNullable(
-          ServiceManager.getService(PsiDocumentManager.class).getPsiFile(openProject, document));
+        ApplicationManager.getApplication().getService(PsiDocumentManager.class).getPsiFile(openProject, document));
     }
 
     return Optional.empty();

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/FileDocumentListener.java
@@ -1,6 +1,6 @@
 package org.zalando.intellij.swagger.ui.provider;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManagerListener;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -16,16 +16,16 @@ public class FileDocumentListener implements FileDocumentManagerListener {
   @Override
   public void beforeDocumentSaving(@NotNull final Document document) {
     final Optional<PsiFile> psiFile =
-        ServiceManager.getService(PsiFileService.class).fromDocument(document);
+      ApplicationManager.getApplication().getService(PsiFileService.class).fromDocument(document);
 
     psiFile.ifPresent(
         file -> {
-          IndexFacade indexFacade = ServiceManager.getService(IndexFacade.class);
+          IndexFacade indexFacade = ApplicationManager.getApplication().getService(IndexFacade.class);
           if (indexFacade.isIndexReady(file.getProject())) {
             final Optional<VirtualFile> specFile = indexFacade.getMainSpecFile(file);
 
             SwaggerFileService swaggerFileService =
-                ServiceManager.getService(SwaggerFileService.class);
+              ApplicationManager.getApplication().getService(SwaggerFileService.class);
             specFile.ifPresent(swaggerFileService::convertSwaggerToHtmlAsync);
           }
         });

--- a/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
+++ b/src/main/java/org/zalando/intellij/swagger/ui/provider/SwaggerUiUrlProvider.java
@@ -1,7 +1,7 @@
 package org.zalando.intellij.swagger.ui.provider;
 
 import com.intellij.ide.browsers.OpenInBrowserRequest;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
@@ -28,7 +28,7 @@ public class SwaggerUiUrlProvider extends BuiltInWebBrowserUrlProvider implement
   @Nullable
   @Override
   protected Url getUrl(@NotNull OpenInBrowserRequest request, @NotNull VirtualFile file) {
-    SwaggerFileService swaggerFileService = ServiceManager.getService(SwaggerFileService.class);
+    SwaggerFileService swaggerFileService = ApplicationManager.getApplication().getService(SwaggerFileService.class);
     Optional<Path> swaggerHTMLFolder =
         swaggerFileService.convertSwaggerToHtml(request.getVirtualFile());
 


### PR DESCRIPTION
No deprecation warnings reported anymore:
```
IC-222.4459.24 against org.zalando.intellij.swagger:1.1.2: Compatible
IC-221.6008.13 against org.zalando.intellij.swagger:1.1.2: Compatible
IC-223.8836.35 against org.zalando.intellij.swagger:1.1.2: Compatible
IC-231.8109.2 against org.zalando.intellij.swagger:1.1.2: Compatible
```