### PR TITLE
Minor build changes: drop Travis and Coveralls, add Dependabot, add html test report

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-dist: trusty
-jdk:
-  - openjdk11
-after_success:
-  - ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/zalando/intellij-swagger.svg?branch=master)](https://travis-ci.org/zalando/intellij-swagger)
-[![Coverage Status](https://coveralls.io/repos/github/zalando/intellij-swagger/badge.svg?branch=master)](https://coveralls.io/github/zalando/intellij-swagger?branch=master) [![Join the chat at https://gitter.im/zalando/intellij-swagger](https://badges.gitter.im/zalando/intellij-swagger.svg)](https://gitter.im/zalando/intellij-swagger?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Plugin](https://github.com/zalando/intellij-swagger/actions/workflows/build.yml/badge.svg)](https://github.com/zalando/intellij-swagger/actions/workflows/build.yml)
 
 # Swagger Plugin
 Swagger Plugin makes it easy to edit Swagger and OpenAPI specification files inside IntelliJ IDEA. You can find it on JetBrains' [plugin page](https://plugins.jetbrains.com/plugin/8347).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ buildscript {
 plugins {
     id("org.jetbrains.intellij") version "1.13.2"
     id("jacoco")
-    id("com.github.kt3k.coveralls") version "2.12.2"
     id("com.diffplug.spotless") version "6.17.0"
     id("idea")
     id("java")
@@ -45,10 +44,19 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation("org.mockito:mockito-core:5.2.0")
 }
+
 tasks {
     jacocoTestReport {
+        dependsOn(test) // tests are required to run before generating the report
         reports {
-            xml.required.set(true) // coveralls plugin depends on xml format report
+            xml.required.set(true)
+            html.required.set(true)
+        }
+    }
+    test {
+        finalizedBy(jacocoTestReport) // report is always generated after tests run
+        reports {
+            junitXml.required.set(false)
             html.required.set(true)
         }
     }


### PR DESCRIPTION
- Travis has not been working since 2021 so remove and replace badge with the GitHub one
- Add Dependabot
- Add html test report (not published yet as the setup seems bit [annoying](https://github.com/marketplace/actions/test-reporter#recommended-setup-for-public-repositories) when forks are supported.
- Make sure jacoco always runs
- Drop link to Gitter (not monitored by anyone)
- Drop Coverals - not sure if we want to use it, but for now it's not getting updated so prefer to remove