### PR TITLE
Allow to provide release notes, do not commit versions changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,8 @@ tasks {
     }
     patchPluginXml {
         untilBuild.set("") // null will add until-build to the plugin.xml
+        version.set(project.findProperty("version")?.toString() ?: "DEV")
+        changeNotes.set(project.findProperty("changeNotes")?.toString() ?: "none")
     }
 }
 

--- a/release.sh
+++ b/release.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$#" -lt 2 || -z "${1}" || -z "${2}" ]]
+if [[ "$#" -lt 3 || -z "${1}" || -z "${2}" || -z "${3}" ]]
   then
-    echo "Version and release channel need to be provided."
-    echo "Usage: ./release.sh <version> <release-channel>"
+    echo "Version, release channel and release notes need to be provided."
+    echo "Usage: ./release.sh <version> <release-channel> <release-notes>"
     exit 1
 fi
 
@@ -28,17 +28,10 @@ if [[ -z "${JETBRAINS_HUB_TOKEN:-}" ]]
     exit 1
 fi
 
-NEW_VERSION=$1
-
-if [[ "$(uname)" == "Darwin" ]]
+if [[ "$(git branch --show-current)" != "master" ]]
   then
-    SED_ARG=(-i "")
-else
-    SED_ARG=(-i)
+    echo "Please use master branch"
+    exit 1
 fi
-sed "${SED_ARG[@]}" "s/<version>.*<\/version>/<version>$NEW_VERSION<\/version>/g" src/main/resources/META-INF/plugin.xml
-git checkout master
-./gradlew publishPlugin -Pversion="${NEW_VERSION}" -PjetbrainsReleaseChannel="${2}" -x buildSearchableOptions
-git add src/main/resources/META-INF/plugin.xml
-git commit -m "Bump version"
 
+./gradlew publishPlugin -Pversion="${1}" -PjetbrainsReleaseChannel="${2}" -PchangeNotes="${3}" -x buildSearchableOptions

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+DEFAULT_BRANCH="master"
+
 if [[ "$#" -lt 3 || -z "${1}" || -z "${2}" || -z "${3}" ]]
   then
     echo "Version, release channel and release notes need to be provided."
@@ -28,9 +30,9 @@ if [[ -z "${JETBRAINS_HUB_TOKEN:-}" ]]
     exit 1
 fi
 
-if [[ "$(git branch --show-current)" != "master" ]]
+if [[ "$(git branch --show-current)" != "${DEFAULT_BRANCH}" ]]
   then
-    echo "Please use master branch"
+    echo "Please use ${DEFAULT_BRANCH} branch"
     exit 1
 fi
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>org.zalando.intellij.swagger</id>
     <name>Swagger</name>
-    <version>1.1.2</version>
+    <version>DEV</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
- Allow to provide release notes (probably just a link to the GH milestone)
- Do not commit version numbers from release script
- Use patchPluginXml to set the version number instead of sed