### PR TITLE
Update Jackson to 2.15.0 and use BOM dependency to manage Jackson dependency versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,12 +35,13 @@ repositories {
 }
 
 dependencies {
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.15.0"))
     implementation("commons-io:commons-io:2.11.0")
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.google.guava:guava:31.1-jre")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2")
-    implementation("com.fasterxml.jackson.core:jackson-core:2.14.2")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+    implementation("com.fasterxml.jackson.core:jackson-core")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation("org.mockito:mockito-core:5.3.1")
 }


### PR DESCRIPTION
To avoid having multiple dependabot PR's for managing Jackson dependencies, I changed the project to instead import Jackson's BOM.