### PR TITLE
Fixes blank built-in preview in 2022.x

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/service/SwaggerFilesUtils.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/SwaggerFilesUtils.java
@@ -4,7 +4,6 @@ import com.intellij.util.Url;
 import com.intellij.util.Urls;
 import java.io.File;
 import java.nio.file.Path;
-
 import org.jetbrains.annotations.NotNull;
 
 public class SwaggerFilesUtils {

--- a/src/main/java/org/zalando/intellij/swagger/service/SwaggerFilesUtils.java
+++ b/src/main/java/org/zalando/intellij/swagger/service/SwaggerFilesUtils.java
@@ -1,15 +1,16 @@
 package org.zalando.intellij.swagger.service;
 
-import com.intellij.util.LocalFileUrl;
 import com.intellij.util.Url;
+import com.intellij.util.Urls;
 import java.io.File;
 import java.nio.file.Path;
+
 import org.jetbrains.annotations.NotNull;
 
 public class SwaggerFilesUtils {
 
   public static Url convertSwaggerLocationToUrl(@NotNull final Path swaggerHtmlDirectory) {
-    return new LocalFileUrl(swaggerHtmlDirectory.toString() + File.separator + "index.html");
+    return Urls.newUri("file", swaggerHtmlDirectory + File.separator + "index.html");
   }
 
   public static boolean isFileReference(final String text) {


### PR DESCRIPTION
It seems the `LocalFileUrl` is missing the `file` schema internally leading to an empty preview (IntelliJ Ultimate 2022.x). Using the `Urls.newUri()` and providing the `file` schema explicitly fixes the problem.

![image](https://user-images.githubusercontent.com/2333584/236496976-062dc3d3-d5e5-463b-aea4-8f2994e2e499.png)
