### PR TITLE
Rename plugin to Zalando OpenAPI Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Build Plugin](https://github.com/zalando/intellij-swagger/actions/workflows/build.yml/badge.svg)](https://github.com/zalando/intellij-swagger/actions/workflows/build.yml)
 
-# Swagger Plugin
-Swagger Plugin makes it easy to edit Swagger and OpenAPI specification files inside IntelliJ IDEA. You can find it on JetBrains' [plugin page](https://plugins.jetbrains.com/plugin/8347).
+# Zalando OpenAPI Editor
+Zalando OpenAPI Editor makes it easy to edit OpenAPI and Swagger specification files inside IntelliJ IDEA. You can find it on JetBrains' [plugin page](https://plugins.jetbrains.com/plugin/8347).
 
-![Swagger Plugin features](https://github.com/zalando/intellij-swagger/blob/master/docs/features.gif?raw=true)
+![Zalando OpenAPI Editor features](https://github.com/zalando/intellij-swagger/blob/master/docs/features.gif?raw=true)
 
 ## Usage
 
-Open a Swagger or OpenAPI specification file, that's it.
+Open an OpenAPI or Swagger specification file, that's it.
 
 ## Custom Extensions
 
@@ -24,7 +24,7 @@ See the [Zalando extension example](https://github.com/zalando/intellij-swagger/
 
 ## Development
 
-Developing the Swagger Plugin is easy, just execute the following command:
+Developing the Zalando OpenAPI Editor is easy, just execute the following command:
 
 ```./gradlew runIde```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ intellij {
 }
 
 group = "org.zalando.intellij"
-version = if (project.hasProperty("version")) project.version else "0.0.1"
+version = if (project.version != Project.DEFAULT_VERSION) project.version else "SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -67,8 +67,8 @@ tasks {
     }
     patchPluginXml {
         untilBuild.set("") // null will add until-build to the plugin.xml
-        version.set(project.findProperty("version")?.toString() ?: "DEV")
-        changeNotes.set(project.findProperty("changeNotes")?.toString() ?: "none")
+        version.set(project.version.toString())
+        changeNotes.set(project.findProperty("changeNotes")?.toString())
     }
 }
 

--- a/examples/extensions-zalando/README.md
+++ b/examples/extensions-zalando/README.md
@@ -1,5 +1,5 @@
-# Swagger Plugin Zalando Extension
-Zalando's architecture centers around microservices, and each API is documented with a Swagger specification. Zalando has its own [API Guidelines](https://opensource.zalando.com/restful-api-guidelines) that extends the standard Swagger specification. This extension example illustrates how the Swagger Plugin can be extended to support Zalando specific guidelines for REST APIs.
+# Zalando OpenAPI Editor with Zalando Extensions
+Zalando's architecture centers around microservices, and each API is documented with an OpenAPI specification. Zalando has its own [API Guidelines](https://opensource.zalando.com/restful-api-guidelines) that extends the standard OpenAPI specification. This extension example illustrates how the Zalando OpenAPI Editor can be extended to support Zalando specific guidelines for REST APIs.
 
 ![Zalando Extension (x-audience)](https://github.com/zalando/intellij-swagger/blob/master/docs/extensions-zalando.png?raw=true)
 

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
-<idea-plugin version="2">
+<idea-plugin>
     <id>org.zalando.intellij.swagger.examples.extensions.zalando</id>
-    <name>Swagger [Zalando Extensions]</name>
+    <name>Zalando OpenAPI Editor with Zalando Extensions</name>
     <version>0.0.5</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,20 +1,16 @@
 <idea-plugin>
     <id>org.zalando.intellij.swagger</id>
     <name>Swagger</name>
-    <version>DEV</version>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
 
     <description><![CDATA[
-     <p>A plugin to help you easily edit Swagger and Open API specification files.</p><br/>
+     <p>A plugin to help you easily edit Open API and Swagger specification files.</p><br/>
 
      <p>Like this plugin? <b>Give it a star</b> at <a href="https://github.com/zalando/intellij-swagger">GitHub</a> and spread the word!</p>
     ]]></description>
-
-    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="2022.1"/> <!-- since-build will be patched by the build -->
 
     <extensionPoints>
         <extensionPoint qualifiedName="org.zalando.intellij.swagger.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>org.zalando.intellij.swagger</id>
-    <name>Swagger</name>
+    <name>Zalando OpenAPI Editor</name>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
As discussed internally, let's have a bit more descriptive and up-to-date name.

The plugin-id is not changed.