### PR TITLE
Increase minimum supported IDEA version to 2022.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Validate Gradle Wrapper

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,15 +18,15 @@ intellij {
     //Bundled plugin dependencies
     plugins.set(listOf("yaml", "com.intellij.java", "org.jetbrains.plugins.yaml"))
     pluginName.set("intellij-swagger")
-    version.set("2022.1") // Recommended to use the lowest supported version to compile against
+    version.set("2022.3") // Recommended to use the lowest supported version to compile against
 }
 
 group = "org.zalando.intellij"
 version = if (project.version != Project.DEFAULT_VERSION) project.version else "SNAPSHOT"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {


### PR DESCRIPTION
2022.3 requires Java 17 so this allows the plugin to use Java 17. Secondly, also allows to merge this PR: https://github.com/zalando/intellij-swagger/pull/381.

Let's release 1.3 and merge this only after it.
