### PR TITLE
Address the 'No space left on device' issue in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
 
+    # Address the "No space left on device" issue
+    # From here: https://github.com/jlumbroso/free-disk-space
+    - name: Free disk space
+      run: sudo rm -rf /usr/local/lib/android || true
+
     - name: Assemble plugin
       run: ./gradlew assemble
 


### PR DESCRIPTION
The builds have been failing with `System.IO.IOException: No space left on device` for ~3 weeks. First failure: https://github.com/zalando/intellij-swagger/actions/runs/6110174965

Unfortunately GH maps it to Skipped and shows it as green:
<img width="574" alt="Screenshot 2023-10-01 at 11 52 07" src="https://github.com/zalando/intellij-swagger/assets/8832826/8b37061a-3fdf-420b-a922-41016b7c8421">
