### PR TITLE
Mark extension points dynamic

### DIFF
--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiJsonCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiJsonCompletionContributor.java
@@ -54,7 +54,7 @@ public class OpenApiJsonCompletionContributor extends CompletionContributor {
             OpenApiFieldCompletionFactory.from(completionHelper, result)
                 .ifPresent(FieldCompletion::fill);
             for (OpenApiCustomFieldCompletionFactory ep :
-                OpenApiCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
+                OpenApiCustomFieldCompletionFactory.EP_NAME.getExtensionList()) {
               ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
             }
           } else {
@@ -62,7 +62,7 @@ public class OpenApiJsonCompletionContributor extends CompletionContributor {
                     completionHelper, CompletionResultSetFactory.forValue(parameters, result))
                 .ifPresent(ValueCompletion::fill);
             for (OpenApiCustomValueCompletionFactory ep :
-                OpenApiCustomValueCompletionFactory.EP_NAME.getExtensions()) {
+                OpenApiCustomValueCompletionFactory.EP_NAME.getExtensionList()) {
               ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
             }
           }

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiYamlCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiYamlCompletionContributor.java
@@ -58,12 +58,12 @@ public class OpenApiYamlCompletionContributor extends CompletionContributor {
               .ifPresent(ValueCompletion::fill);
 
           for (OpenApiCustomFieldCompletionFactory ep :
-              OpenApiCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
+              OpenApiCustomFieldCompletionFactory.EP_NAME.getExtensionList()) {
             ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
           }
 
           for (OpenApiCustomValueCompletionFactory ep :
-              OpenApiCustomValueCompletionFactory.EP_NAME.getExtensions()) {
+              OpenApiCustomValueCompletionFactory.EP_NAME.getExtensionList()) {
             ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
           }
 

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerJsonCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerJsonCompletionContributor.java
@@ -54,7 +54,7 @@ public class SwaggerJsonCompletionContributor extends CompletionContributor {
             SwaggerFieldCompletionFactory.from(completionHelper, result)
                 .ifPresent(FieldCompletion::fill);
             for (SwaggerCustomFieldCompletionFactory ep :
-                SwaggerCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
+                SwaggerCustomFieldCompletionFactory.EP_NAME.getExtensionList()) {
               ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
             }
           } else {
@@ -62,7 +62,7 @@ public class SwaggerJsonCompletionContributor extends CompletionContributor {
                     completionHelper, CompletionResultSetFactory.forValue(parameters, result))
                 .ifPresent(ValueCompletion::fill);
             for (SwaggerCustomValueCompletionFactory ep :
-                SwaggerCustomValueCompletionFactory.EP_NAME.getExtensions()) {
+                SwaggerCustomValueCompletionFactory.EP_NAME.getExtensionList()) {
               ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
             }
           }

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerYamlCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/swagger/SwaggerYamlCompletionContributor.java
@@ -58,12 +58,12 @@ public class SwaggerYamlCompletionContributor extends CompletionContributor {
               .ifPresent(ValueCompletion::fill);
 
           for (SwaggerCustomFieldCompletionFactory ep :
-              SwaggerCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
+              SwaggerCustomFieldCompletionFactory.EP_NAME.getExtensionList()) {
             ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
           }
 
           for (SwaggerCustomValueCompletionFactory ep :
-              SwaggerCustomValueCompletionFactory.EP_NAME.getExtensions()) {
+              SwaggerCustomValueCompletionFactory.EP_NAME.getExtensionList()) {
             ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
           }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,10 +13,18 @@
     ]]></description>
 
     <extensionPoints>
-        <extensionPoint qualifiedName="org.zalando.intellij.swagger.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory"/>
-        <extensionPoint qualifiedName="org.zalando.intellij.swagger.customValueFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomValueCompletionFactory"/>
-        <extensionPoint qualifiedName="org.zalando.intellij.openapi.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomFieldCompletionFactory"/>
-        <extensionPoint qualifiedName="org.zalando.intellij.openapi.customValueFactory" interface="org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomValueCompletionFactory"/>
+        <extensionPoint qualifiedName="org.zalando.intellij.swagger.customFieldFactory"
+                        interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory"
+                        dynamic="true"/>
+        <extensionPoint qualifiedName="org.zalando.intellij.swagger.customValueFactory"
+                        interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomValueCompletionFactory"
+                        dynamic="true"/>
+        <extensionPoint qualifiedName="org.zalando.intellij.openapi.customFieldFactory"
+                        interface="org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomFieldCompletionFactory"
+                        dynamic="true"/>
+        <extensionPoint qualifiedName="org.zalando.intellij.openapi.customValueFactory"
+                        interface="org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomValueCompletionFactory"
+                        dynamic="true"/>
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
The plugin does not store extension references, so the extension points can be marked as dynamic (https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html#dynamic-extension-points). In addition, switch to recommended method for getting extensions.