### PR TITLE
2024.3 support - add com.intellij.modules.json dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,8 @@ plugins {
 
 intellij {
     //Bundled plugin dependencies
-    plugins.set(listOf("yaml", "com.intellij.java", "org.jetbrains.plugins.yaml"))
+    // "com.intellij.modules.json" to be added when minimum required version is at least 2024.3
+    plugins.set(listOf("com.intellij.java", "org.jetbrains.plugins.yaml"))
     pluginName.set("intellij-swagger")
     version.set("2022.3") // Recommended to use the lowest supported version to compile against
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,13 @@
     <name>Zalando OpenAPI Editor</name>
     <vendor email="sebastian.monte@zalando.de" url="https://tech.zalando.com/">Zalando SE</vendor>
 
+    <!-- Module dependencies -->
+    <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>
+    <depends>com.intellij.modules.json</depends>  <!-- Bundled plugin starting from 2024.3 -->
+
+    <!-- Bundled plugin dependencies -->
+    <depends>com.intellij.java</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
 
     <description><![CDATA[


### PR DESCRIPTION
#455

PluginVerifier does not flag the issue, so unclear if this is enough. If it isn't, the plugin needs to be added to the plugins list in build.gradle.kts. This means that either the minimum supported Idea version needs to be bumped to 2024.3 or that multiple versions targeting different Idea versions need to be published.

