### PR TITLE
Remove Gradle versions plugin due to dependabot integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
     id("com.diffplug.spotless") version "7.0.2"
     id("idea")
     id("java")
-    id("com.github.ben-manes.versions") version "0.51.0"
 }
 
 intellij {


### PR DESCRIPTION
Based on the discussion in #468, we decided to remove the plugin as we use dependabot for dependency updates in this project.